### PR TITLE
Add "disabled" class binding to checkbox's div

### DIFF
--- a/addon/components/sl-checkbox.js
+++ b/addon/components/sl-checkbox.js
@@ -25,7 +25,14 @@ export default Ember.Component.extend( TooltipEnabled, {
      *
      * @property {Ember.Array} classNames
      */
-    classNames: [ 'checkbox', 'form-group', 'sl-checkbox' ]
+    classNames: [ 'checkbox', 'form-group', 'sl-checkbox' ],
+
+    /**
+     * Bindings for the base component class
+     *
+     * @property {Ember.Array} classNameBindings
+     */
+    classNameBindings: [ 'disabled' ]
 
     // -------------------------------------------------------------------------
     // Actions


### PR DESCRIPTION
Without the checkbox's surrounding div having "disabled" class on it, Bootstrap was not styling the label text for disabled status to match the input's disabled style.
