### PR TITLE
Fix sl-ember components endpoint

### DIFF
--- a/blueprints/sl-ember-components/index.js
+++ b/blueprints/sl-ember-components/index.js
@@ -24,7 +24,7 @@ module.exports = {
                 return self.addBowerPackageToProject( 'typeahead.js' );
             })
             .then( function() {
-                return self.addBowerPackageToProject( 'git@github.com:softlayer/sl-ember-components.git' );
+                return self.addBowerPackageToProject( 'softlayer/sl-ember-components' );
             });
     },
 


### PR DESCRIPTION
git@github(ssh) urls requires the user to have a github account with ssh keys. bower will default to git://github.com when using this shorthand and that will work in most situations.

p.s.
git@github.com vs https:// vs git://github.com
git://github.com by using shorthand appears the way most packages implement this.
