### PR TITLE
Remove duplicate Less import statements

### DIFF
--- a/app/styles/sl-ember-components.less
+++ b/app/styles/sl-ember-components.less
@@ -5,14 +5,12 @@
 @import 'sl-calendar';
 @import 'sl-date-picker';
 @import 'sl-drop-button';
-@import 'sl-input';
-@import 'sl-select';
-@import 'sl-grid';
 @import 'sl-filter';
-@import 'sl-menu';
-@import 'sl-pagination';
+@import 'sl-grid';
+@import 'sl-input';
 @import 'sl-loading-icon';
 @import 'sl-menu';
+@import 'sl-pagination';
 @import 'sl-panel';
 @import 'sl-progress-bar';
 @import 'sl-select';


### PR DESCRIPTION
Both sl-menu.less and sl-select.less were being included twice.
