### PR TITLE
Update bower include, replace incorrect blueprint line

### DIFF
--- a/blueprints/sl-ember-components/index.js
+++ b/blueprints/sl-ember-components/index.js
@@ -24,7 +24,7 @@ module.exports = {
                 return self.addBowerPackageToProject( 'typeahead.js' );
             })
             .then( function() {
-                return self.addBowerPackageToProject( 'softlayer/sl-ember-components' );
+                return self.addBowerPackageToProject( 'softlayer/sl-bootstrap' );
             });
     },
 

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "moment-timezone": "~0.2.5",
     "select2": "~3.5.2",
     "typeahead.js": "~0.10.5",
-    "sl-bootstrap": "https://github.com/softlayer/sl-bootstrap.git"
+    "sl-bootstrap": "softlayer/sl-bootstrap#1.0.0"
   },
   "devDependencies": {
     "sinonjs": "~1.10.2",


### PR DESCRIPTION
For some reason, "sl-ember-components" was incorrectly used in place of "sl-bootstrap".

Also updated repo syntax in bower.json to match condensed version.
