### PR TITLE
Close #329 - Add ability to set class attributes on sl-menu components

### DIFF
--- a/addon/components/sl-menu.js
+++ b/addon/components/sl-menu.js
@@ -338,6 +338,13 @@ export default Ember.Component.extend({
     children: null,
 
     /**
+     * Additional class names to be added to the classNames attribute
+     *
+     * @type {String[]}
+     */
+    extraClassNames: [],
+
+    /**
      * @property {boolean} isRoot
      * @default  true
      */
@@ -393,6 +400,22 @@ export default Ember.Component.extend({
      */
     initChildren: function() {
         this.set( 'children', [] );
+    }.on( 'init' ),
+
+    /**
+     * Initialize initClassNames array
+     *
+     * @function initClassNames
+     * @observes "init" event
+     * @returns  {undefined}
+     */
+    initClassNames: function() {
+        var classNames = this.get( 'classNames' ),
+            extraClassNames = this.get( 'extraClassNames' );
+
+        if ( extraClassNames && extraClassNames.length > 0 ) {
+            classNames.push.apply(classNames, extraClassNames);
+        }
     }.on( 'init' ),
 
     /**

--- a/addon/components/sl-menu.js
+++ b/addon/components/sl-menu.js
@@ -406,14 +406,14 @@ export default Ember.Component.extend({
      * Initialize initClassNames array
      *
      * @function initClassNames
-     * @observes "init" event
-     * @returns  {undefined}
+     * @observes init
+     * @returns {undefined}
      */
     initClassNames: function() {
         var classNames = this.get( 'classNames' ),
             extraClassNames = this.get( 'extraClassNames' );
 
-        if ( extraClassNames && extraClassNames.length > 0 ) {
+        if ( !Ember.isNone( extraClassNames ) ) {
             classNames.push.apply(classNames, extraClassNames);
         }
     }.on( 'init' ),

--- a/app/templates/components/sl-menu.hbs
+++ b/app/templates/components/sl-menu.hbs
@@ -5,7 +5,7 @@
 {{#if menu.pages}}
     <ul {{bind-attr class="view.isRoot:list-inline"}}>
         {{#each page in menu.pages}}
-            {{sl-menu tagName="li" menuBinding="page" isRoot=false}}
+            {{sl-menu extraClassNames=page.classNames tagName="li" menuBinding="page" isRoot=false}}
         {{/each}}
 
         {{#if view.displayShowAll}}

--- a/tests/dummy/app/routes/demos/sl-menu.js
+++ b/tests/dummy/app/routes/demos/sl-menu.js
@@ -5,7 +5,7 @@ export default Ember.Route.extend({
 
     model: function() {
         return  Ember.Object.create({ label: null, pages: [
-            Ember.Object.create({ label: 'Colors', pages: [
+            Ember.Object.create({ label: 'Colors', classNames: [ 'current' ], pages: [
                 Ember.Object.create({ label: 'Red', action: function() { alert( 'The color RED' ); }}),
                 Ember.Object.create({ label: 'Green', action: function() { alert( 'The color GREEN' ); }}),
                 Ember.Object.create({ label: 'Blue', action: function() { alert( 'The color BLUE' ); }})

--- a/tests/dummy/app/templates/demos/sl-menu.hbs
+++ b/tests/dummy/app/templates/demos/sl-menu.hbs
@@ -59,7 +59,8 @@
         Used to provide the underlying structure of the entire menu. This expects an Ember.Object with a <code>pages</code> attribute that contains an Ember.Array of other nodes. Each node, including the top level, can have the following attributes:
         <ul>
             <li><strong>pages</strong> - An array of nodes that will be embedded under the <code>label</code> attribute as a sub-menu.</li>
-            <li><strong>label</strong> - The label of the menu itself. This should be <em>null</em> for top level menus and will provide the name of the sub-menu for sub-menu lists</li>
+            <li><strong>label</strong> - The label of the menu itself. This should be <em>null</em> for top level menus and will provide the name of the sub-menu for sub-menu lists.</li>
+            <li><strong>classNames</strong> - An array of class names to be added to the element's <code>class</code> attribute.</li>
             <li><strong>action</strong> - This can either be a string, which will be received by the <code>actionInitiated</code> binding on the template or can actually be a function that will be executed when the item is selected with either a mouse click or through a keyboard shortcut.</li>
             <li><strong>route</strong> - This can be used to specify a route to which the application will transition if the menu item is selected.
         </ul>

--- a/tests/unit/components/sl-menu-test.js
+++ b/tests/unit/components/sl-menu-test.js
@@ -7,7 +7,7 @@ var clickCounter = 0,
     modelStub = {
         label: null,
         pages: [
-            { label: 'Top Level A', pages: [
+            { label: 'Top Level A', classNames: [ 'class1', 'class2' ], pages: [
                 { label: 'Option A1', action: 'MyAction' },
                 { label: 'Option A2', action: function() { clickCounter = 0; clickCounter++; }},
                 { label: 'Option A3', action: { actionName: 'MyAction', data: { name: 'Joe' }}},
@@ -41,6 +41,22 @@ test( '"children" property is an empty array on initialization', function( asser
 
     assert.equal( Ember.typeOf( component.get( 'children' ) ), 'array', 'Is array' );
     assert.equal( component.get( 'children' ).length, 0, 'Array is empty' );
+});
+
+test( 'Class attributes are properly initialized', function( assert ) {
+    var component  = this.subject({ menu: modelStub }),
+        $component = this.render(),
+        menus = $component.find( 'li' ),
+        firstMenuClasses,
+        secondMenuClasses;
+
+    firstMenuClasses = $( menus[0] ).attr( 'class' ).split( ' ' );
+    assert.ok( firstMenuClasses.indexOf( 'class1' ), '"class1" is added to the first menu element class' );
+    assert.ok( firstMenuClasses.indexOf( 'class2' ), '"class2" is added to the first menu element class' );
+    assert.ok( firstMenuClasses.indexOf( 'sl-menu' ), '"sl-menu" is added to the first menu element class' );
+
+    secondMenuClasses = $( menus[1] ).attr( 'class' ).split( ' ' );
+    assert.ok( secondMenuClasses.indexOf( 'sl-menu' ), '"sl-menu" is added to a menu when no classNames property is present' );
 });
 
 test( 'Menu creates correct DOM structure', function( assert ) {


### PR DESCRIPTION
Custom classes can be added to an sl-menu's element by including an optional classNames property to the menu object. The value should be an array of strings, each of which will be pushed to the corresponding sl-menu's classNames attribute, which is bound to that menu's element's class attribute.