### PR TITLE
Temporarily add ember-release to allowe TravisCI failures until addon…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
 matrix:
     fast_finish: true
     allow_failures:
+        - env: EMBER_TRY_SCENARIO=ember-release
         - env: EMBER_TRY_SCENARIO=ember-beta
         - env: EMBER_TRY_SCENARIO=ember-canary
 


### PR DESCRIPTION
… is updated to Ember 1.13