### PR TITLE
Make size a SafeString when size is not a number

### DIFF
--- a/addon/components/sl-grid-cell.js
+++ b/addon/components/sl-grid-cell.js
@@ -168,10 +168,13 @@ export default Ember.Component.extend({
         'column.size',
         function() {
             let size = this.get( 'column.size' );
+            let value = '';
 
             if ( Ember.typeOf( size ) === 'number' ) {
-                return Ember.String.htmlSafe( `width: ${size}px;` );
+                value = `width: ${size}px;`;
             }
+
+            return Ember.String.htmlSafe( value );
         }
     )
 


### PR DESCRIPTION
Fix for
WARNING: Binding style attributes may introduce cross-site scripting vulnerabilities; please ensure that values being bound are properly escaped. For more information, including how to disable this warning, see http://emberjs.com/deprecations/v1.x/#toc_binding-style-attributes.