### PR TITLE
Closes softlayer/sl-ember-components#26,#245

### DIFF
--- a/addon/mixins/sl-tooltip-enabled.js
+++ b/addon/mixins/sl-tooltip-enabled.js
@@ -59,6 +59,10 @@ export default Ember.Mixin.create({
         Ember.on(
             'didInsertElement',
             function() {
+                Ember.assert(
+                    'observer/tooltip.enable() expects the parameter "title" to be provided',
+                    this.get( 'title' )
+                );
                 if ( this.get( 'popover' ) ) {
                     this.enablePopover();
                 } else if ( this.get( 'title' ) ) {
@@ -79,6 +83,11 @@ export default Ember.Mixin.create({
      * @returns {undefined}
      */
     enablePopover() {
+        Ember.assert(
+            'method/enablePopover() expects the parameter "popover" to be a string',
+            'string' === Ember.typeOf ( this.get( 'popover' ) )
+        );
+
         let popover = this.get( 'popover' );
 
         // First-time rendering
@@ -105,6 +114,11 @@ export default Ember.Mixin.create({
      * @returns {undefined}
      */
     enableTooltip() {
+        Ember.assert(
+            'method/enableTooltip() expects the parameter "title" to be a string',
+            'string' === Ember.typeOf ( this.get( 'title' ) )
+        );
+
         let title = this.get( 'title' );
 
         // First-time rendering

--- a/addon/mixins/sl-tooltip-enabled.js
+++ b/addon/mixins/sl-tooltip-enabled.js
@@ -59,10 +59,6 @@ export default Ember.Mixin.create({
         Ember.on(
             'didInsertElement',
             function() {
-                Ember.assert(
-                    'observer/tooltip.enable() expects the parameter "title" to be provided',
-                    this.get( 'title' )
-                );
                 if ( this.get( 'popover' ) ) {
                     this.enablePopover();
                 } else if ( this.get( 'title' ) ) {
@@ -84,8 +80,12 @@ export default Ember.Mixin.create({
      */
     enablePopover() {
         Ember.assert(
-            'method/enablePopover() expects the parameter "popover" to be a string',
+            'method/enablePopover() expects the parameter "popover" and for it to be a string',
             'string' === Ember.typeOf ( this.get( 'popover' ) )
+        );
+        Ember.assert(
+            'method/enablePopover() expects the parameter "title" and for it to be a string',
+            'string' === Ember.typeOf ( this.get( 'title' ) )
         );
 
         let popover = this.get( 'popover' );
@@ -115,7 +115,7 @@ export default Ember.Mixin.create({
      */
     enableTooltip() {
         Ember.assert(
-            'method/enableTooltip() expects the parameter "title" to be a string',
+            'method/enableTooltip() expects the parameter "title" and for it to be a string',
             'string' === Ember.typeOf ( this.get( 'title' ) )
         );
 

--- a/tests/unit/components/sl-tooltip-test.js
+++ b/tests/unit/components/sl-tooltip-test.js
@@ -12,3 +12,73 @@ test( 'Expected Mixin is present', function( assert ) {
         'Expected Mixin is present'
     );
 });
+
+test( 'enabledTooltip() - Verify classes are set correctly: data-toggle and data-original-title', function( assert ) {
+    this.subject( { title: 'Tooltip Text' } );
+
+    assert.equal(
+        this.$().attr( 'data-toggle' ),
+        'tooltip',
+        'Has class "data-toggle"'
+    );
+
+    assert.equal(
+        this.$().attr( 'data-original-title' ),
+        'Tooltip Text',
+        'Has class "data-original-title"'
+    );
+});
+
+test( 'enabledTooltip() - Verify only correct title is set', function( assert ) {
+    this.subject( { title: 'Tooltip Text' } );
+
+    assert.equal(
+        this.$().attr( 'data-toggle' ),
+        'tooltip',
+        'Has class "data-toggle"'
+    );
+
+    assert.notEqual(
+        this.$().attr( 'data-original-title' ),
+        'Wrong Title',
+        'Has class "data-original-title"'
+    );
+});
+
+test( 'enablePopover() - Verify classes are set correctly: data-toggle and data-original-title', function( assert ) {
+    this.subject({
+        popover: 'Popover content',
+        title: 'Popover Text'
+    });
+
+    assert.equal(
+        this.$().attr( 'data-toggle' ),
+        'popover',
+        'Has class "data-toggle"'
+    );
+
+    assert.equal(
+        this.$().attr( 'data-original-title' ),
+        'Popover Text',
+        'Has class "data-original-title"'
+    );
+});
+
+test( 'enablePopover() - Verify only correct title is set', function( assert ) {
+    this.subject({
+        popover: 'Popover content',
+        title: 'Popover Text'
+    });
+
+    assert.equal(
+        this.$().attr( 'data-toggle' ),
+        'popover',
+        'Has class "data-toggle"'
+    );
+
+    assert.notEqual(
+        this.$().attr( 'data-original-title' ),
+        'Wrong Text',
+        'Has class "data-original-title"'
+    );
+});


### PR DESCRIPTION
Added tests for sl-tooltip and asserts for verifying default types. This work was being tracked as issues: 26 and 245.