### PR TITLE
Update sl-eslint version

### DIFF
--- a/blueprints/sl-ember-components/index.js
+++ b/blueprints/sl-ember-components/index.js
@@ -1,7 +1,5 @@
 module.exports = {
     afterInstall: function() {
-        const self = this;
-
         return this.addBowerPackagesToProject([
             {
                 name: 'bootstrap-datepicker',

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "ember build",
     "docs": "ember ember-cli-jsdoc",
     "lint": "node_modules/.bin/sl-eslint",
-    "lint-all": "node_modules/.bin/sl-eslint addon app blueprints tests",
+    "lint-all": "node_modules/.bin/sl-eslint addon app tests",
     "start": "ember server",
     "test": "ember test"
   },
@@ -67,6 +67,6 @@
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
     "ember-try": "0.0.6",
-    "sl-eslint": "0.0.8"
+    "sl-eslint": "0.0.9"
   }
 }


### PR DESCRIPTION
Also removed an unneeded line in the blueprint file, and removed the blueprints/ directory from the lint-all command (blueprints are not ES2015-compatible, so our ESLint would fail for a number of rules when running it).