### PR TITLE
Added vimrc to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 npm-debug.log
 testem.log
 *.swp
+.vimrc


### PR DESCRIPTION
So that projects can have their own .vimrc files with project specific settings without getting accidentally checked in.