### PR TITLE
Fix sl-drop-button

### DIFF
--- a/addon/components/sl-button.js
+++ b/addon/components/sl-button.js
@@ -51,7 +51,7 @@ export default Ember.Component.extend( StreamEnabled, TooltipEnabled, {
     /** @type {String[]} */
     attributeBindings: [
         'data-target',
-        'data-toggle',
+        'dataToggle:data-toggle',
         'disabled',
         'type'
     ],


### PR DESCRIPTION
`data-toggle` was changed to `dataToggle` in the `sl-drop-button` template but was never changed in the `sl-button` component attributeBindings. `sl-drop-button` mixes in `sl-button` hence `sl-drop-button` was not displaying dropdown options when clicked because it was missing the `data-toggle='dropdown'` attribute.