### PR TITLE
Closes softlayer/sl-ember-components#509

### DIFF
--- a/addon/components/sl-modal-header.js
+++ b/addon/components/sl-modal-header.js
@@ -45,7 +45,13 @@ export default Ember.Component.extend({
     ariaLabelledBy: Ember.computed(
         'elementId',
         function() {
-            return 'modalTitle' + this.get( 'elementId' );
+            const elementId = this.get( 'elementId' );
+
+            if ( elementId ) {
+                return 'modalTitle' + elementId;
+            }
+
+            return null;
         }
     )
 });


### PR DESCRIPTION
added a check for elementId in the ariaLabeldBy computed property of sl-modal-header. returns null if it doesn't exist.