### PR TITLE
tabindex- and pattern-support for inputs

### DIFF
--- a/addon/templates/components/sl-checkbox.hbs
+++ b/addon/templates/components/sl-checkbox.hbs
@@ -1,4 +1,4 @@
 <label>
-    {{input checked=checked disabled=disabled name=name type="checkbox"}}
+    {{input checked=checked disabled=disabled name=name tabindex=tabindex type="checkbox"}}
     {{label}}
 </label>

--- a/addon/templates/components/sl-date-picker.hbs
+++ b/addon/templates/components/sl-date-picker.hbs
@@ -7,6 +7,7 @@
     class="date-picker form-control"
     disabled=disabled
     placeholder=placeholder
+    tabindex=tabindex
     value=value
 }}
 

--- a/addon/templates/components/sl-input.hbs
+++ b/addon/templates/components/sl-input.hbs
@@ -19,6 +19,8 @@
     placeholder=placeholder
     readonly=readonlyString
     value=value
+    tabindex=tabindex
+    pattern=pattern
 }}
 
 {{#if helpText}}

--- a/addon/templates/components/sl-radio.hbs
+++ b/addon/templates/components/sl-radio.hbs
@@ -6,6 +6,7 @@
         id=inputId
         name=name
         readonly=readonly
+        tabindex=tabindex
         value=value}}
 
     {{label}}

--- a/tests/dummy/app/templates/demos/sl-input.hbs
+++ b/tests/dummy/app/templates/demos/sl-input.hbs
@@ -190,6 +190,10 @@
         When true, the component is styled to reflect optional status. This styling will only be in effect if the <code>label</code> property has also been set.
     {{/property-text}}
 
+    {{#property-text name="pattern" type="String"}}
+        HTML5 Regex-Pattern which lets browsers validate the inputs value.
+    {{/property-text}}
+
     {{#property-text name="placeholder" type="String"}}
         <code>placeholder</code> attribute value for the input.
     {{/property-text}}
@@ -212,6 +216,10 @@
 
     {{#property-text name="suggestions" type="Array"}}
         Values to use as typeahead suggestions.
+    {{/property-text}}
+
+    {{#property-text name="tabindex" type="Integer"}}
+        Sets the HTML tabindex-attribute.
     {{/property-text}}
 
     {{#property-text name="title" type="String"}}


### PR DESCRIPTION
Hey,

I just made a very minor update which adds tabindex- and pattern-support for inputs. (also see #680)

Since those attributes are already available in embers components, nothing special had to be done.

If you want to have real attributes on .JS-Level for those, the input-mixin might be a good place, but since it is currently _not_ used by the checkbox- and radiobutton-component I didn't do so.

Just let me know what you think. I needed this for a current project anyway..

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/softlayer/sl-ember-components/688)
<!-- Reviewable:end -->
