### PR TITLE
Upgrade sl-eslint tool to v0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
     "ember-sinon": "0.2.1",
     "ember-try": "0.0.6",
     "phantomjs": "1.9.18",
-    "sl-eslint": "0.2.2"
+    "sl-eslint": "0.2.3"
   }
 }


### PR DESCRIPTION
This version includes an exception to the "new-cap" rule for Ember.A() method.