### PR TITLE
Deprecation warning fix

### DIFF
--- a/addon/mixins/sl-tooltip-enabled.js
+++ b/addon/mixins/sl-tooltip-enabled.js
@@ -59,6 +59,23 @@ export default Ember.Mixin.create({
     // Observers
 
     /**
+     * Initialize mixin properties
+     *
+     * @function
+     * @returns {undefined}
+     */
+    initialize: Ember.on(
+        'init',
+        function() {
+            if ( this.get( 'popover' ) ) {
+                this.set( 'dataToggle', 'popover' );
+            } else if ( this.get( 'tooltip' ) ) {
+                this.set( 'dataToggle', 'tooltip' );
+            }
+        }
+    ),
+
+    /**
      * Enable the tooltip functionality, based on component's
      * `popover` attribute or component's `title` attribute
      *
@@ -96,8 +113,6 @@ export default Ember.Mixin.create({
 
         // First-time rendering
         if ( 'undefined' === Ember.typeOf( originalTitle ) ) {
-            this.set( 'dataToggle', 'popover' );
-
             this.$().popover({
                 content: popover,
                 placement: 'top'
@@ -123,8 +138,6 @@ export default Ember.Mixin.create({
 
         // First-time rendering
         if ( 'undefined' === Ember.typeOf( originalTitle ) ) {
-            this.set( 'dataToggle', 'tooltip' );
-
             this.$().tooltip({
                 container: 'body',
                 title: title

--- a/addon/mixins/sl-tooltip-enabled.js
+++ b/addon/mixins/sl-tooltip-enabled.js
@@ -14,7 +14,6 @@ export default Ember.Mixin.create({
 
     /** @type {String[]} */
     attributeBindings: [
-        'dataToggle:data-toggle',
         'dataTrigger:data-trigger',
         'title'
     ],
@@ -27,13 +26,6 @@ export default Ember.Mixin.create({
 
     // -------------------------------------------------------------------------
     // Properties
-
-    /**
-     * dataToggle property
-     *
-     * @type {?String}
-     */
-    dataToggle: null,
 
     /**
      * dataTrigger property
@@ -57,23 +49,6 @@ export default Ember.Mixin.create({
 
     // -------------------------------------------------------------------------
     // Observers
-
-    /**
-     * Initialize mixin properties
-     *
-     * @function
-     * @returns {undefined}
-     */
-    initialize: Ember.on(
-        'init',
-        function() {
-            if ( this.get( 'popover' ) ) {
-                this.set( 'dataToggle', 'popover' );
-            } else if ( this.get( 'tooltip' ) ) {
-                this.set( 'dataToggle', 'tooltip' );
-            }
-        }
-    ),
 
     /**
      * Enable the tooltip functionality, based on component's

--- a/tests/unit/mixins/sl-tooltip-enabled-test.js
+++ b/tests/unit/mixins/sl-tooltip-enabled-test.js
@@ -46,12 +46,6 @@ test( 'Default values are set correctly', function( assert ) {
     const subject = testObject.create();
 
     assert.strictEqual(
-        subject.get( 'dataToggle' ),
-        null,
-        'dataToggle is null'
-    );
-
-    assert.strictEqual(
         subject.get( 'dataTrigger' ),
         null,
         'dataTrigger is null'
@@ -133,12 +127,6 @@ test( 'enabledTooltip() - Renders tooltip', function( assert ) {
     subject.enableTooltip();
 
     assert.equal(
-        subject.get( 'dataToggle' ),
-        'tooltip',
-        '"dataToggle" has correct value'
-    );
-
-    assert.equal(
         temporaryData.tooltip.container,
         'body',
         'tooltip container is set to correct value'
@@ -180,12 +168,6 @@ test( 'enablePopover() - Renders popover', function( assert ) {
     const subject = testObject.create();
 
     subject.enablePopover();
-
-    assert.equal(
-        subject.get( 'dataToggle' ),
-        'popover',
-        '"dataToggle" has correct value'
-    );
 
     assert.equal(
         temporaryData.popover.content,


### PR DESCRIPTION
@notmessenger after reading the [docs](http://getbootstrap.com/javascript/#tooltips) carefully I discovered that we do *not* need the `data-toggle` attribute unless we are initializing the tooltip or popover using a general attribute selector. 
>For performance reasons, the Tooltip and Popover data-apis are opt-in, meaning you must initialize them yourself.
>One way to initialize all tooltips on a page would be to select them by their data-toggle attribute:
```
$(function () {
  $('[data-toggle="tooltip"]').tooltip()
})
```

We initialize the tooltip/popover for each specific element.
`this.$().tooltip({....});`

Hence do not need a `data-toggle` attribute for selection purposes. I have removed the `data-toggle` attribute. Let me know if you disagree or find that my conclusions are wrong.