### PR TITLE
Closes softlayer/sl-ember-components#550

### DIFF
--- a/addon/components/sl-date-range-picker.js
+++ b/addon/components/sl-date-range-picker.js
@@ -1,11 +1,13 @@
 import Ember from 'ember';
+import ComponentInputId from '../mixins/sl-component-input-id';
 import layout from '../templates/components/sl-date-range-picker';
 
 /**
  * @module
  * @augments ember/Component
+ * @augments module:mixins/sl-component-input-id
  */
-export default Ember.Component.extend({
+export default Ember.Component.extend( ComponentInputId, {
 
     // -------------------------------------------------------------------------
     // Dependencies
@@ -43,13 +45,6 @@ export default Ember.Component.extend({
      * @type {String}
      */
     format: 'mm/dd/yyyy',
-
-    /**
-     * Bound value of Start Date input element's id
-     *
-     * @type {?String}
-     */
-    inputElementId: null,
 
     /**
      * The last valid date for the date range

--- a/addon/templates/components/sl-date-range-picker.hbs
+++ b/addon/templates/components/sl-date-range-picker.hbs
@@ -1,5 +1,5 @@
 {{#if label}}
-    <label for={{inputElementId}}>{{label}}</label>
+    <label for={{inputId}}>{{label}}</label>
 {{/if}}
 
 <div class="row">
@@ -9,7 +9,7 @@
         placeholder=startDatePlaceholder
         startDate=minDate
         value=startDateValue
-        inputElementId=inputElementId
+        inputId=inputId
         format=format
     }}
 

--- a/tests/dummy/app/templates/demos/sl-date-range-picker.hbs
+++ b/tests/dummy/app/templates/demos/sl-date-range-picker.hbs
@@ -27,6 +27,16 @@
 
 <hr>
 
+<h3>Mixins used</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-component-input-id</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>Properties</h3>
 
 <div class="list-group">

--- a/tests/unit/components/sl-date-range-picker-test.js
+++ b/tests/unit/components/sl-date-range-picker-test.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import { skip } from 'qunit';
 import sinon from 'sinon';
+import ComponentInputId from 'sl-ember-components/mixins/sl-component-input-id';
 
 moduleForComponent(
     'sl-date-range-picker',
@@ -14,6 +15,13 @@ moduleForComponent(
         unit: true
     }
 );
+
+test( 'Expected Mixins are present', function( assert ) {
+    assert.ok(
+        ComponentInputId.detect( this.subject() ),
+        'ComponentInputId Mixin is present'
+    );
+});
 
 test( 'Default classNames are present', function( assert ) {
     this.subject();
@@ -175,7 +183,7 @@ test( 'label is accepted as a parameter', function( assert ) {
 
     assert.equal(
         this.$( 'label' ).prop( 'for' ),
-        component.get( 'inputElementId' ),
+        component.get( 'inputId' ),
         'label element has the correct for property'
     );
 

--- a/tests/unit/components/sl-date-range-picker-test.js
+++ b/tests/unit/components/sl-date-range-picker-test.js
@@ -19,7 +19,7 @@ moduleForComponent(
 test( 'Expected Mixins are present', function( assert ) {
     assert.ok(
         ComponentInputId.detect( this.subject() ),
-        'ComponentInputId Mixin is present'
+        'sl-component-input-id mixin is present'
     );
 });
 


### PR DESCRIPTION
Fix deprecation message in sl-date-range-picker by incorporating the sl-component-input-id mixin, updated component template, docs and tests.