### PR TITLE
Closes softlayer/sl-ember-components#553

### DIFF
--- a/addon/components/sl-date-picker.js
+++ b/addon/components/sl-date-picker.js
@@ -1,13 +1,15 @@
 import Ember from 'ember';
+import ComponentInputId from '../mixins/sl-component-input-id';
 import TooltipEnabled from '../mixins/sl-tooltip-enabled';
 import layout from '../templates/components/sl-date-picker';
 
 /**
  * @module
  * @augments ember/Component
+ * @augments module:mixins/sl-component-input-id
  * @augments module:mixins/sl-tooltip-enabled
  */
-export default Ember.Component.extend( TooltipEnabled, {
+export default Ember.Component.extend( ComponentInputId, TooltipEnabled, {
 
     // -------------------------------------------------------------------------
     // Dependencies
@@ -114,16 +116,6 @@ export default Ember.Component.extend( TooltipEnabled, {
      * @type {String}
      */
     helpText: null,
-
-    /**
-     * The input field's id attribute
-     *
-     * Used to expose this value externally for use in this component and when
-     * composing this component into others.
-     *
-     * @type {?String}
-     */
-    inputElementId: null,
 
     /**
      * A list of inputs to be used in a range picker
@@ -244,25 +236,6 @@ export default Ember.Component.extend( TooltipEnabled, {
 
     // -------------------------------------------------------------------------
     // Observers
-
-    /**
-     * Captures and sets the input field's id attribute.
-     *
-     * This is used to expose this value externally for use when composing this
-     * component into others.
-     *
-     * @function
-     * @returns {undefined}
-     */
-    setInputElementId: Ember.on(
-        'didInsertElement',
-        function() {
-            this.set(
-                'inputElementId',
-                this.$( 'input.date-picker' ).prop( 'id' )
-            );
-        }
-    ),
 
     /**
      * Setup the bootstrap-datepicker plugin and events

--- a/addon/templates/components/sl-date-picker.hbs
+++ b/addon/templates/components/sl-date-picker.hbs
@@ -1,11 +1,12 @@
 {{#if label}}
-    <label for={{inputElementId}}>{{label}}</label>
+    <label for={{inputId}}>{{label}}</label>
 {{/if}}
 
 {{input
     type="text"
     class="date-picker form-control"
     disabled=disabled
+    id=inputId
     placeholder=placeholder
     value=value
 }}

--- a/tests/dummy/app/templates/demos/sl-date-picker.hbs
+++ b/tests/dummy/app/templates/demos/sl-date-picker.hbs
@@ -29,6 +29,16 @@
 
 <hr>
 
+<h3>Mixins used</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-component-input-id</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>Properties</h3>
 
 <div class="list-group">

--- a/tests/unit/components/sl-date-picker-test.js
+++ b/tests/unit/components/sl-date-picker-test.js
@@ -1,9 +1,17 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import sinon from 'sinon';
+import ComponentInputId from 'sl-ember-components/mixins/sl-component-input-id';
 
 moduleForComponent( 'sl-date-picker', 'Unit | Component | sl date picker', {
     unit: true
+});
+
+test( 'Expected Mixins are present', function( assert ) {
+    assert.ok(
+        ComponentInputId.detect( this.subject() ),
+        'ComponentInputId Mixin is present'
+    );
 });
 
 test( 'Default class names are present', function( assert ) {
@@ -86,12 +94,6 @@ test( 'Default properties are set correctly', function( assert ) {
         component.get( 'helpText' ),
         null,
         'The "helpText" default value is correct'
-    );
-
-    assert.equal(
-        component.get( 'inputElementId' ),
-        null,
-        'The "inputElementId" default value is correct'
     );
 
     assert.equal(
@@ -179,15 +181,26 @@ test( 'Default properties are set correctly', function( assert ) {
     );
 });
 
-test( 'setInputElementId() - sets inputElementId correctly', function( assert ) {
-    const component = this.subject();
-
-    const inputElementId = this.$( 'input.date-picker' ).prop( 'id' );
+test( 'label is accepted as a parameter', function( assert ) {
+    const labelText = 'lorem ipsum';
+    const component = this.subject({ label: labelText });
 
     assert.equal(
-        component.get( 'inputElementId' ),
-        inputElementId,
-        "'inputElementId' set correctly"
+        this.$( 'label' ).html(),
+        labelText,
+        'label element was created with label parameter text'
+    );
+
+    assert.equal(
+        this.$( 'label' ).prop( 'for' ),
+        component.get( 'inputId' ),
+        'label element has the correct for property'
+    );
+
+    assert.equal(
+        this.$( 'label' ).prop( 'for' ),
+        this.$( 'input' ).prop( 'id' ),
+        'label is used for date input'
     );
 });
 

--- a/tests/unit/components/sl-date-picker-test.js
+++ b/tests/unit/components/sl-date-picker-test.js
@@ -10,7 +10,7 @@ moduleForComponent( 'sl-date-picker', 'Unit | Component | sl date picker', {
 test( 'Expected Mixins are present', function( assert ) {
     assert.ok(
         ComponentInputId.detect( this.subject() ),
-        'ComponentInputId Mixin is present'
+        'sl-component-input-id mixin is present'
     );
 });
 


### PR DESCRIPTION
Fix deprecation message in sl-date-picker by incorporating the sl-component-input-id mixin, updated component template, docs and tests.