### PR TITLE
 Refactor "spellcheck" property #802 

### DIFF
--- a/addon/components/sl-textarea.js
+++ b/addon/components/sl-textarea.js
@@ -94,7 +94,7 @@ export default Ember.Component.extend( InputBased, TooltipEnabled, ComponentInpu
      *
      * Accepted values "false" (default) or "true".
      *
-     * @type {Spellcheck}
+     * @type {Boolean}
      */
     spellcheck: false,
 

--- a/addon/components/sl-textarea.js
+++ b/addon/components/sl-textarea.js
@@ -92,8 +92,6 @@ export default Ember.Component.extend( InputBased, TooltipEnabled, ComponentInpu
     /**
      * The `spellcheck` HTML attribute value
      *
-     * Accepted values "false" (default) or "true".
-     *
      * @type {Boolean}
      */
     spellcheck: false,
@@ -119,5 +117,4 @@ export default Ember.Component.extend( InputBased, TooltipEnabled, ComponentInpu
 
     // -------------------------------------------------------------------------
     // Methods
-
 });

--- a/addon/components/sl-textarea.js
+++ b/addon/components/sl-textarea.js
@@ -17,18 +17,6 @@ export const Direction = Object.freeze({
 });
 
 /**
- * Valid values for `spellcheck` property
- *
- * @memberof module:components/sl-textarea
- * @enum {Boolean|String}
- */
-export const Spellcheck = {
-    DEFAULT: 'default',
-    FALSE: false,
-    TRUE: true
-};
-
-/**
  * Valid values for `wrap` property
  *
  * @memberof module:components/sl-textarea
@@ -104,11 +92,11 @@ export default Ember.Component.extend( InputBased, TooltipEnabled, ComponentInpu
     /**
      * The `spellcheck` HTML attribute value
      *
-     * Accepted values are true, false, "default" (default), "true", or "false".
+     * Accepted values "false" (default) or "true".
      *
      * @type {Spellcheck}
      */
-    spellcheck: Spellcheck.Direction,
+    spellcheck: false,
 
     /**
      * The bound value of the textarea

--- a/tests/dummy/app/templates/demos/sl-textarea.hbs
+++ b/tests/dummy/app/templates/demos/sl-textarea.hbs
@@ -123,8 +123,8 @@
         The <code>selectionStart</code> HTML attribute value, passed directly to the underlying &lt;textarea&gt;.
     {{/property-text}}
 
-    {{#property-text name="spellcheck" type="Boolean/String" default="\"default\""}}
-        The <code>spellcheck</code> HTML attribute value, passed directly to the underlying &lt;textarea&gt;. Can be true, false, or "default".
+    {{#property-text name="spellcheck" type="Boolean" default="\"false\""}}
+        The <code>spellcheck</code> HTML attribute value, passed directly to the underlying &lt;textarea&gt;. Can be true, false.
     {{/property-text}}
 
     {{#property-text name="tabindex" type="String"}}

--- a/tests/dummy/app/templates/demos/sl-textarea.hbs
+++ b/tests/dummy/app/templates/demos/sl-textarea.hbs
@@ -123,8 +123,8 @@
         The <code>selectionStart</code> HTML attribute value, passed directly to the underlying &lt;textarea&gt;.
     {{/property-text}}
 
-    {{#property-text name="spellcheck" type="Boolean" default="\"false\""}}
-        The <code>spellcheck</code> HTML attribute value, passed directly to the underlying &lt;textarea&gt;. Can be true, false.
+    {{#property-text name="spellcheck" type="Boolean" default="false"}}
+        The <code>spellcheck</code> HTML attribute value, passed directly to the underlying &lt;textarea&gt;.
     {{/property-text}}
 
     {{#property-text name="tabindex" type="String"}}

--- a/tests/integration/components/sl-textarea-test.js
+++ b/tests/integration/components/sl-textarea-test.js
@@ -17,3 +17,57 @@ test( 'for attribute value on label matches id of textarea', function( assert ) 
         wrapper.find( 'textarea' ).attr( 'id' )
     );
 });
+
+test( '"spellcheck" property is supported', function( assert ) {
+    this.render( hbs`
+        {{#sl-textarea spellcheck=true}}
+        {{/sl-textarea}}
+    ` );
+
+    const wrapper = this.$( '>:first-child' );
+
+    assert.strictEqual(
+        wrapper.find( 'textarea' ).attr( 'spellcheck' ),
+        'true',
+        'Textarea spellcheck attribute is expected value'
+    );
+});
+
+test( '"spellcheck" property is supported with bound values', function( assert ) {
+    this.set( 'spellcheck', true );
+    this.render( hbs`
+        {{#sl-textarea spellcheck=spellcheck}}
+        {{/sl-textarea}}
+    ` );
+
+    const wrapper = this.$( '>:first-child' );
+
+    assert.strictEqual(
+        wrapper.find( 'textarea' ).attr( 'spellcheck' ),
+        'true',
+        'Textarea spellcheck attribute is expected value'
+    );
+
+    this.set( 'spellcheck', false );
+
+    assert.strictEqual(
+        wrapper.find( 'textarea' ).attr( 'spellcheck' ),
+        'false',
+        'Textarea spellcheck attribute is expected value'
+    );
+});
+
+test( '"spellcheck" property defaults correctly', function( assert ) {
+    this.render( hbs`
+        {{#sl-textarea}}
+        {{/sl-textarea}}
+    ` );
+
+    const wrapper = this.$( '>:first-child' );
+
+    assert.strictEqual(
+        wrapper.find( 'textarea' ).attr( 'spellcheck' ),
+        'false',
+        'Textarea spellcheck attribute default value is false'
+    );
+});

--- a/tests/integration/components/sl-textarea-test.js
+++ b/tests/integration/components/sl-textarea-test.js
@@ -10,11 +10,9 @@ test( 'for attribute value on label matches id of textarea', function( assert ) 
         {{sl-textarea label="test label"}}
     ` );
 
-    const wrapper = this.$( '>:first-child' );
-
     assert.equal(
-        wrapper.find( 'label' ).attr( 'for' ),
-        wrapper.find( 'textarea' ).attr( 'id' )
+        this.$( '>:first-child' ).find( 'label' ).attr( 'for' ),
+        this.$( '>:first-child' ).find( 'textarea' ).attr( 'id' )
     );
 });
 
@@ -24,10 +22,8 @@ test( '"spellcheck" property is supported', function( assert ) {
         {{/sl-textarea}}
     ` );
 
-    const wrapper = this.$( '>:first-child' );
-
     assert.strictEqual(
-        wrapper.find( 'textarea' ).attr( 'spellcheck' ),
+        this.$( '>:first-child' ).find( 'textarea' ).attr( 'spellcheck' ),
         'true',
         'Textarea spellcheck attribute is expected value'
     );
@@ -40,10 +36,8 @@ test( '"spellcheck" property is supported with bound values', function( assert )
         {{/sl-textarea}}
     ` );
 
-    const wrapper = this.$( '>:first-child' );
-
     assert.strictEqual(
-        wrapper.find( 'textarea' ).attr( 'spellcheck' ),
+        this.$( '>:first-child' ).find( 'textarea' ).attr( 'spellcheck' ),
         'true',
         'Textarea spellcheck attribute is expected value'
     );
@@ -51,7 +45,7 @@ test( '"spellcheck" property is supported with bound values', function( assert )
     this.set( 'spellcheck', false );
 
     assert.strictEqual(
-        wrapper.find( 'textarea' ).attr( 'spellcheck' ),
+        this.$( '>:first-child' ).find( 'textarea' ).attr( 'spellcheck' ),
         'false',
         'Textarea spellcheck attribute is expected value'
     );
@@ -63,10 +57,8 @@ test( '"spellcheck" property defaults correctly', function( assert ) {
         {{/sl-textarea}}
     ` );
 
-    const wrapper = this.$( '>:first-child' );
-
     assert.strictEqual(
-        wrapper.find( 'textarea' ).attr( 'spellcheck' ),
+        this.$( '>:first-child' ).find( 'textarea' ).attr( 'spellcheck' ),
         'false',
         'Textarea spellcheck attribute default value is false'
     );


### PR DESCRIPTION
In this PR it was decided to remove the Spellcheck enum from sl-textarea component.

The enum that represented the Spellcheck property was originally defaulted to the value "default" which is a wrong/invalid value. Removing that would leave the enum redefining a boolean so ultimately we removed that enum all together as it served no purpose. Essentially we set the defaulted value of the Spellcheck property to false because a false and an absence of an attribute are equivalent according to w3. source below.

Boolean attributes are explained here: http://www.w3.org/TR/html4/intro/sgmltut.html#h-3.3.4.2

Some attributes play the role of boolean variables (e.g., the selected attribute for the OPTION element). Their appearance in the start tag of an element implies that the value of the attribute is "true". Their absence implies a value of "false".
