### PR TITLE
Closes softlayer/sl-ember-behavior#557

### DIFF
--- a/addon/components/sl-grid.js
+++ b/addon/components/sl-grid.js
@@ -394,7 +394,7 @@ export default Ember.Component.extend({
      * @returns {undefined}
      */
     handleNewContent: Ember.observer(
-        'content.@each',
+        'content.[]',
         function() {
             this.set( 'loading', false );
 


### PR DESCRIPTION
Removed deprecated `@each` in Ember.observer() call