### PR TITLE
Install ember-cli-blanket, providing test code coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /dist
 /tmp
 /docs
+coverage.json
 
 # dependencies
 /node_modules

--- a/bower.json
+++ b/bower.json
@@ -23,5 +23,7 @@
     "rxjs": "~2.5.2",
     "sinonjs": "~1.14.1"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "blanket": "~1.1.5"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "broccoli-string-replace": "0.0.2",
     "ember-cli": "1.13.8",
     "ember-cli-app-version": "0.5.0",
+    "ember-cli-blanket": "0.5.4",
     "ember-cli-dependency-checker": "^1.0.1",
     "ember-cli-doc-server": "1.1.0",
     "ember-cli-htmlbars-inline-precompile": "^0.2.0",

--- a/testem.json
+++ b/testem.json
@@ -1,6 +1,6 @@
 {
     "framework": "qunit",
-    "test_page": "tests/index.html?hidepassed&nojshint",
+    "test_page": "tests/index.html?coverage&hidepassed&nojshint",
     "disable_watching": true,
     "launch_in_ci": [
         "PhantomJS"

--- a/tests/blanket-options.js
+++ b/tests/blanket-options.js
@@ -1,0 +1,20 @@
+/* globals blanket, module */
+
+var options = {
+  modulePrefix: 'sl-ember-components',
+  filter: '//.*sl-ember-components/.*/',
+  antifilter: '//.*(tests|template).*/',
+  loaderExclusions: [],
+  enableCoverage: true,
+  modulePattern: "\/(\\w+)",
+  branchTracking: true,
+  cliOptions: {
+    reporters: ['json'],
+    autostart: true
+  }
+};
+if (typeof exports === 'undefined') {
+  blanket.options(options);
+} else {
+  module.exports = options;
+}

--- a/tests/blanket-options.js
+++ b/tests/blanket-options.js
@@ -1,20 +1,21 @@
 /* globals blanket, module */
 
-var options = {
-  modulePrefix: 'sl-ember-components',
-  filter: '//.*sl-ember-components/.*/',
-  antifilter: '//.*(tests|template).*/',
-  loaderExclusions: [],
-  enableCoverage: true,
-  modulePattern: "\/(\\w+)",
-  branchTracking: true,
-  cliOptions: {
-    reporters: ['json'],
-    autostart: true
-  }
+const options = {
+    modulePrefix: 'sl-ember-components',
+    filter: '//.*sl-ember-components/.*/',
+    antifilter: '//.*(tests|template).*/',
+    loaderExclusions: [],
+    enableCoverage: true,
+    modulePattern: '\/(\\w+)',
+    branchTracking: true,
+    cliOptions: {
+        reporters: [ 'json' ],
+        autostart: true
+    }
 };
-if (typeof exports === 'undefined') {
-  blanket.options(options);
+
+if ( 'undefined' === typeof exports ) {
+    blanket.options( options );
 } else {
-  module.exports = options;
+    module.exports = options;
 }

--- a/tests/index.html
+++ b/tests/index.html
@@ -14,6 +14,13 @@
         <link rel="stylesheet" href="/assets/dummy.css">
         <link rel="stylesheet" href="/assets/test-support.css">
 
+        <style>
+        #blanket-main {
+            position: relative;
+            z-index: 99999;
+        }
+        </style>
+
         {{content-for 'head-footer'}}
         {{content-for 'test-head-footer'}}
     </head>
@@ -24,6 +31,8 @@
         <script src="/assets/vendor.js"></script>
         <script src="/assets/test-support.js"></script>
         <script src="/assets/dummy.js"></script>
+        <script src="/assets/blanket-options.js"></script>
+        <script src="/assets/blanket-loader.js"></script>
         <script src="/testem.js"></script>
         <script src="/assets/test-loader.js"></script>
 


### PR DESCRIPTION
* A console error occurs that is described in https://github.com/sglanzer/ember-cli-blanket/issues/85
* A console error occurs that is resolved by https://github.com/sglanzer/ember-cli-blanket/pull/83
* Due to https://github.com/sglanzer/ember-cli-blanket/issues/84 it is not possible to use the lcov reporter, which could be used to integrate into TravisCI, Code Climate and coveralls.io.  For now the data is only accessible via the `#/tests` url when using `ember serve`