### PR TITLE
Closes softlayer/sl-ember-components#900

### DIFF
--- a/addon/components/sl-grid.js
+++ b/addon/components/sl-grid.js
@@ -201,19 +201,6 @@ export default Ember.Component.extend({
     // -------------------------------------------------------------------------
     // Events
 
-    /**
-     * Post-template insert hook to set column heading default widths
-     *
-     * @function
-     * @returns {undefined}
-     */
-    didInsertElement: function() {
-        const colHeaders = $( '.list-pane .column-headers tr:first th' );
-        this.$( '.list-pane .content > table tr:first td' ).each( function( index ) {
-            colHeaders.eq( index ).width( $( this ).width() );
-        });
-    },
-
     // -------------------------------------------------------------------------
     // Properties
 
@@ -431,6 +418,22 @@ export default Ember.Component.extend({
                     this.updateHeight();
                 });
             }
+        }
+    ),
+
+    /**
+     * Setup the widths for column headers that were not given widths
+     *
+     * @function
+     * @returns {undefined}
+     */
+    setupColumnHeaderWidths: Ember.on(
+        'didInsertElement',
+        function() {
+            const colHeaders = $( '.list-pane .column-headers tr:first th' );
+            this.$( '.list-pane .content > table tr:first td' ).each( function( index ) {
+                colHeaders.eq( index ).width( $( this ).width() );
+            });
         }
     ),
 

--- a/addon/components/sl-grid.js
+++ b/addon/components/sl-grid.js
@@ -201,6 +201,19 @@ export default Ember.Component.extend({
     // -------------------------------------------------------------------------
     // Events
 
+    /**
+     * Post-template insert hook to set column heading default widths
+     *
+     * @function
+     * @returns {undefined}
+     */
+    didInsertElement: function() {
+        const colHeaders = $( '.list-pane .column-headers tr:first th' );
+        this.$( '.list-pane .content > table tr:first td' ).each( function( index ) {
+            colHeaders.eq( index ).width( $( this ).width() );
+        });
+    },
+
     // -------------------------------------------------------------------------
     // Properties
 

--- a/addon/templates/components/sl-grid.hbs
+++ b/addon/templates/components/sl-grid.hbs
@@ -36,8 +36,10 @@
                 {{/each}}
 
                 {{#if rowActions}}
-                    <th class="actions-cell"></th>
+                    <th class="actions-cell column-small"></th>
                 {{/if}}
+
+                <th class="fake-scrollbar"></th>
             </tr>
         </thead>
     </table>
@@ -56,7 +58,7 @@
                         {{/each}}
 
                         {{#if rowActions}}
-                            <td class="actions-cell">
+                            <td class="actions-cell column-small">
                                 {{#sl-drop-button
                                     align="right"
                                     label=actionsButtonLabel

--- a/app/styles/sl-grid.less
+++ b/app/styles/sl-grid.less
@@ -59,7 +59,7 @@
     }
 
     .fake-scrollbar {
-        width: 16px;
+        width: 17px;
         padding: 0;
     }
 

--- a/app/styles/sl-grid.less
+++ b/app/styles/sl-grid.less
@@ -58,6 +58,11 @@
         }
     }
 
+    .fake-scrollbar {
+        width: 16px;
+        padding: 0;
+    }
+
     .list-pane {
         float: left;
         padding-bottom: 33px;


### PR DESCRIPTION
This should fix the issue of column widths not aligning when a column is set to "auto" or allowed to default.  However, allowing multiple columns to default or setting multiple columns to "auto" will still cause an undesired outcome of headers not aligning properly.

If we intend to support all columns having an automatic width, we need to have a discussion about it.  This could be a major refactor.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/softlayer/sl-ember-components/956)
<!-- Reviewable:end -->
