### PR TITLE
Remove the "tagName: div" default from sl-menu

### DIFF
--- a/addon/components/sl-menu.js
+++ b/addon/components/sl-menu.js
@@ -29,9 +29,6 @@ export default Ember.Component.extend( StreamEnabled, {
     /** @type {Object} */
     layout,
 
-    /** @type {String} */
-    tagName: 'div',
-
     // -------------------------------------------------------------------------
     // Actions
 


### PR DESCRIPTION
Closes softlayer/sl-ember-components#965

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/softlayer/sl-ember-components/966)
<!-- Reviewable:end -->
