### PR TITLE
Updated default test names: Closes softlayer/sl-ember-components#984

### DIFF
--- a/tests/unit/components/sl-button-test.js
+++ b/tests/unit/components/sl-button-test.js
@@ -33,19 +33,19 @@ const mockStreamService = {
     send() {}
 };
 
-test( 'Successfully mixed sl-stream-enabled', function( assert ) {
+test( 'Expected Mixins are present', function( assert ) {
     assert.ok(
-       streamEnabled.detect( this.subject() )
+       streamEnabled.detect( this.subject() ),
+       'Successfully mixed sl-stream-enabled'
+    );
+
+    assert.ok(
+        tooltipEnabled.detect( this.subject() ),
+        'Successfully mixed sl-tooltip-enabled'
     );
 });
 
-test( 'Successfully mixed sl-tooltip-enabled', function( assert ) {
-    assert.ok(
-        tooltipEnabled.detect( this.subject() )
-    );
-});
-
-test( 'Default property values are set correctly', function( assert ) {
+test( 'Default property values', function( assert ) {
     const component = this.subject();
 
     assert.strictEqual(

--- a/tests/unit/components/sl-checkbox-test.js
+++ b/tests/unit/components/sl-checkbox-test.js
@@ -12,7 +12,7 @@ test( 'Expected Mixins are present', function( assert ) {
     );
 });
 
-test( 'Default values are correct', function( assert ) {
+test( 'Default property values', function( assert ) {
     const component = this.subject();
 
     assert.strictEqual(

--- a/tests/unit/components/sl-date-time-test.js
+++ b/tests/unit/components/sl-date-time-test.js
@@ -1,11 +1,19 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
+import TooltipEnabledMixin from 'sl-ember-components/mixins/sl-tooltip-enabled';
 
 moduleForComponent( 'sl-date-time', 'Unit | Component | sl date time', {
     unit: true
 });
 
-test( 'Default class names are present', function( assert ) {
+test( 'Expected Mixins are present', function( assert ) {
+    assert.ok(
+        TooltipEnabledMixin.detect( this.subject() ),
+        'TooltipEnabled Mixin is present'
+    );
+});
+
+test( 'Default property values', function( assert ) {
     this.subject({ timezone: 'America/Chicago' });
 
     assert.ok(

--- a/tests/unit/components/sl-drop-option-test.js
+++ b/tests/unit/components/sl-drop-option-test.js
@@ -6,7 +6,7 @@ moduleForComponent( 'sl-drop-option', 'Unit | Component | sl drop option', {
     unit: true
 });
 
-test( 'Properties have correct default values', function( assert ) {
+test( 'Default property values', function( assert ) {
     const component = this.subject();
 
     assert.strictEqual(

--- a/tests/unit/components/sl-input-test.js
+++ b/tests/unit/components/sl-input-test.js
@@ -78,7 +78,7 @@ test( 'Blur action is triggered when input loses focus', function( assert ) {
     this.$( 'input' ).trigger( 'blur' );
 });
 
-test( 'Default values are correct', function( assert ) {
+test( 'Default property values', function( assert ) {
     const component = this.subject();
 
     assert.strictEqual(

--- a/tests/unit/components/sl-loading-icon-test.js
+++ b/tests/unit/components/sl-loading-icon-test.js
@@ -4,7 +4,7 @@ moduleForComponent( 'sl-loading-icon', 'Unit | Component | sl loading icon', {
     unit: true
 });
 
-test( 'Default property values are set', function( assert ) {
+test( 'Default property values', function( assert ) {
     const component = this.subject();
 
     assert.strictEqual(

--- a/tests/unit/components/sl-modal-footer-test.js
+++ b/tests/unit/components/sl-modal-footer-test.js
@@ -4,7 +4,7 @@ moduleForComponent( 'sl-modal-footer', 'Unit | Component | sl modal footer', {
     unit: true
 });
 
-test( 'Default property values are set correctly', function( assert ) {
+test( 'Default property values', function( assert ) {
     const component = this.subject();
 
     assert.strictEqual(

--- a/tests/unit/components/sl-pagination-test.js
+++ b/tests/unit/components/sl-pagination-test.js
@@ -6,7 +6,7 @@ moduleForComponent( 'sl-pagination', 'Unit | Component | sl pagination', {
     unit: true
 });
 
-test( 'Default property values are set correctly', function( assert ) {
+test( 'Default property values', function( assert ) {
     const component = this.subject();
 
     assert.strictEqual(

--- a/tests/unit/components/sl-panel-test.js
+++ b/tests/unit/components/sl-panel-test.js
@@ -4,7 +4,7 @@ moduleForComponent( 'sl-panel', 'Unit | Component | sl panel', {
     unit: true
 });
 
-test( 'Default properties are correct', function( assert ) {
+test( 'Default property values', function( assert ) {
     const component = this.subject();
 
     assert.strictEqual(

--- a/tests/unit/components/sl-radio-test.js
+++ b/tests/unit/components/sl-radio-test.js
@@ -5,7 +5,7 @@ moduleForComponent( 'sl-radio', 'Unit | Component | sl radio', {
     unit: true
 });
 
-test( 'Correct default property values', function( assert ) {
+test( 'Default property values', function( assert ) {
     const component = this.subject();
 
     assert.strictEqual(

--- a/tests/unit/components/sl-span-test.js
+++ b/tests/unit/components/sl-span-test.js
@@ -4,7 +4,7 @@ moduleForComponent( 'sl-span', 'Unit | Component | sl span', {
     unit: true
 });
 
-test( 'Correct default property values', function( assert ) {
+test( 'Default property values', function( assert ) {
     const component = this.subject();
 
     assert.strictEqual(

--- a/tests/unit/components/sl-textarea-test.js
+++ b/tests/unit/components/sl-textarea-test.js
@@ -36,7 +36,7 @@ test( 'Expected Mixins are present', function( assert ) {
     );
 });
 
-test( 'Correct default property values', function( assert ) {
+test( 'Default property values', function( assert ) {
     const component = this.subject();
 
     assert.strictEqual(

--- a/tests/unit/components/sl-tooltip-test.js
+++ b/tests/unit/components/sl-tooltip-test.js
@@ -6,14 +6,14 @@ moduleForComponent( 'sl-tooltip', 'Unit | Component | sl tooltip', {
     unit: true
 });
 
-test( 'Expected Mixin is present', function( assert ) {
+test( 'Expected Mixins are present', function( assert ) {
     assert.ok(
         TooltipEnabledMixin.detect( this.subject( { title: 'Tooltip Text' } ) ),
         'Expected Mixin is present'
     );
 });
 
-test( 'Default values are correct', function( assert ) {
+test( 'Default property values', function( assert ) {
     const component = this.subject( { title: 'test' } );
 
     assert.equal(

--- a/tests/unit/mixins/sl-tooltip-enabled-test.js
+++ b/tests/unit/mixins/sl-tooltip-enabled-test.js
@@ -39,7 +39,7 @@ test( 'Successfully mixed', function( assert ) {
     );
 });
 
-test( 'Default values are set correctly', function( assert ) {
+test( 'Default property values', function( assert ) {
     const testObject = Ember.Object.extend( mixinUnderTest );
 
     const subject = testObject.create();


### PR DESCRIPTION
Closes softlayer/sl-ember-components#984: https://github.com/softlayer/sl-ember-components/issues/984

Updated the default test's names to: Default property values
Updated mixin test's names to: Expected Mixins are present

This was done for the following components:
sl-button
sl-checkbox
sl-date-time
sl-drop-option
sl-input
sl-loading-icon
sl-modal-footer
sl-pagination
sl-panel
sl-radio
sl-span
sl-textarea
sl-tooltip
sl-tooltip-enabled

There is no longer a unit test for: sl-modal-header so it was not done.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/softlayer/sl-ember-components/1077)
<!-- Reviewable:end -->
