### PR TITLE
Remove default tagName: 'div'

### DIFF
--- a/addon/components/sl-grid.js
+++ b/addon/components/sl-grid.js
@@ -50,9 +50,6 @@ export default Ember.Component.extend({
     /** @type {Object} */
     layout,
 
-    /** @type {String} */
-    tagName: 'div',
-
     // -------------------------------------------------------------------------
     // Actions
 

--- a/addon/components/sl-modal.js
+++ b/addon/components/sl-modal.js
@@ -33,9 +33,6 @@ export default Ember.Component.extend( StreamEnabled, {
         'animated:fade'
     ],
 
-    /** @type {String} */
-    tagName: 'div',
-
     /** @type {Object} */
     layout: layout,
 

--- a/addon/components/sl-radio.js
+++ b/addon/components/sl-radio.js
@@ -32,9 +32,6 @@ export default Ember.Component.extend({
     /** @type {Object} */
     layout,
 
-    /** @type {String} */
-    tagName: 'div',
-
     // -------------------------------------------------------------------------
     // Actions
 

--- a/tests/unit/components/sl-modal-test.js
+++ b/tests/unit/components/sl-modal-test.js
@@ -34,12 +34,6 @@ test( 'Default property values are set correctly', function( assert ) {
     const component = this.subject();
 
     assert.strictEqual(
-        component.get( 'tagName' ),
-        'div',
-        'Default tagName is "div"'
-    );
-
-    assert.strictEqual(
         component.get( 'animated' ),
         true,
         'animated is true by default'

--- a/tests/unit/components/sl-radio-test.js
+++ b/tests/unit/components/sl-radio-test.js
@@ -37,12 +37,6 @@ test( 'Correct default property values', function( assert ) {
         null,
         'Default property "value" is null'
     );
-
-    assert.strictEqual(
-        component.get( 'tagName' ),
-        'div',
-        'Default property "tagName" is string "div"'
-    );
 });
 
 test( 'RadioType property sets relevant class', function( assert ) {


### PR DESCRIPTION
Closes softlayer/sl-ember-components#1078: https://github.com/softlayer/sl-ember-components/issues/1078

Removed the default tagName: 'div' from the following components:
sl-modal
sl-radio
sl-grid

Also removed any tests for default tagName: 'div'

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/softlayer/sl-ember-components/1079)
<!-- Reviewable:end -->
