### PR TITLE
sl-radio-group integration test additions

### DIFF
--- a/addon/components/sl-radio-group.js
+++ b/addon/components/sl-radio-group.js
@@ -63,6 +63,13 @@ export default Ember.Component.extend( InputBased, TooltipEnabled, {
     inline: null,
 
     /**
+     * The component's text label
+     *
+     * @type {?String}
+     */
+    label: null,
+
+    /**
      * The "name" attribute for the children radio buttons
      *
      * Similar to the `inline` property; the default value is null, so the
@@ -74,11 +81,25 @@ export default Ember.Component.extend( InputBased, TooltipEnabled, {
     name: null,
 
     /**
+     * To style the component to reflect that it has optional status.
+     *
+     * @type {Boolean}
+     */
+    optional: false,
+
+    /**
      * Whether the radio buttons should be readonly
      *
      * @type {Boolean}
      */
     readonly: false,
+
+    /**
+     * To style the component to reflect that it has required status.
+     *
+     * @type {Boolean}
+     */
+    required: false,
 
     /**
      * The component's current value property

--- a/tests/integration/components/sl-radio-group-test.js
+++ b/tests/integration/components/sl-radio-group-test.js
@@ -6,6 +6,23 @@ moduleForComponent( 'sl-radio-group', 'Integration | Component | sl radio group'
     integration: true
 });
 
+test( 'Default rendered state', function( assert ) {
+    this.render( hbs`
+        {{#sl-radio-group name="testName"}}
+        {{/sl-radio-group}}
+    ` );
+
+    assert.ok(
+        this.$( '>:first-child' ).hasClass( 'form-group' ),
+        'Has class "form-group"'
+    );
+
+    assert.ok(
+        this.$( '>:first-child' ).hasClass( 'sl-radio-group' ),
+        'Has class "sl-radio-group"'
+    );
+});
+
 test( 'The disabled state applies the disabled attribute and class', function( assert ) {
     this.render( hbs`
         {{#sl-radio-group disabled=true name="testName"}}
@@ -37,6 +54,114 @@ test( 'The disabled state applies to sl-radio children', function( assert ) {
         this.$( '>:first-child' ).find( 'input[disabled]' ).length,
         3,
         'Rendered component has three disabled inputs'
+    );
+});
+
+test( 'The "name" property applies the name attribute to sl-radio children', function( assert ) {
+    this.render( hbs`
+        {{#sl-radio-group name="testName"}}
+            {{sl-radio label="One" value="one"}}
+            {{sl-radio label="Two" value="two"}}
+            {{sl-radio label="Three" value="three"}}
+        {{/sl-radio-group}}
+    ` );
+
+    assert.strictEqual(
+        this.$( '>:first-child' ).find( 'input[name="testName"]' ).length,
+        3,
+        'input has "name" attribute set to correcly passed "name" property'
+    );
+});
+
+test( '"label" property is supported', function( assert ) {
+    this.render( hbs`
+        {{#sl-radio-group
+            name="testName"
+            label="testLabel"
+        }}
+        {{/sl-radio-group}}
+    ` );
+
+    assert.strictEqual(
+        this.$( '>:first-child' ).find( 'label' ).text().trim(),
+        'testLabel',
+        '"label" property sets text inside HTML label tag'
+    );
+});
+
+test( '"optional" property is supported', function( assert ) {
+    this.set( 'optionalTest', false );
+
+    this.render( hbs`
+        {{#sl-radio-group
+            name="testName"
+            label="testLabel"
+            optional=optionalTest
+        }}
+        {{/sl-radio-group}}
+    ` );
+
+    assert.strictEqual(
+        this.$( '>:first-child' ).find( 'label' ).find( 'small' ).length,
+        0,
+        '"optional" property does not add HTML small tag'
+    );
+
+    this.set( 'optionalTest', true );
+
+    assert.strictEqual(
+        this.$( '>:first-child' ).find( 'label' ).find( 'small' ).length,
+        1,
+        '"optional" property adds HTML small tag'
+    );
+
+    assert.ok(
+        this.$( '>:first-child' ).find( 'label' ).find( 'small' ).hasClass( 'text-info' ),
+        '"optional" property sets class "text-info" on HTML small tag'
+    );
+
+    assert.strictEqual(
+        this.$( '>:first-child' ).find( 'label' ).find( 'small' ).text().trim(),
+        'Optional',
+        '"optional" property sets correct text inside HTML small tag'
+    );
+});
+
+test( '"required" property is supported', function( assert ) {
+    this.set( 'requiredTest', false );
+
+    this.render( hbs`
+        {{#sl-radio-group
+            name="testName"
+            label="testLabel"
+            required=requiredTest
+        }}
+        {{/sl-radio-group}}
+    ` );
+
+    assert.strictEqual(
+        this.$( '>:first-child' ).find( 'label' ).find( 'small' ).length,
+        0,
+        '"required" property does not add HTML small tag'
+    );
+
+    this.set( 'requiredTest', true );
+
+    assert.strictEqual(
+        this.$( '>:first-child' ).find( 'label' ).find( 'small' ).length,
+        1,
+        '"required" property adds HTML small tag'
+    );
+
+    assert.ok(
+        this.$( '>:first-child' ).find( 'label' ).find( 'small' ).hasClass( 'text-danger' ),
+        '"required" property sets class "text-danger" on HTML small tag'
+    );
+
+    assert.strictEqual(
+        this.$( '>:first-child' ).find( 'label' ).find( 'small' ).text().trim(),
+        'Required',
+        '"required" property sets correct text inside HTML small tag'
     );
 });
 
@@ -136,5 +261,20 @@ test( 'Default value gets selected by default', function( assert ) {
         this.$( '>:first-child' ).find( 'input[name="testName"]:checked' ).val(),
         'josh',
         'The value "josh" that is set is selected by default'
+    );
+});
+
+test( 'Yielded content passes through', function( assert ) {
+
+    this.render( hbs`
+        {{#sl-radio-group value=value name="testName"}}
+            A content
+        {{/sl-radio-group}}
+    ` );
+
+    assert.strictEqual(
+        this.$( '>:first-child' ).text().trim(),
+        'A content',
+        'Expected content is present'
     );
 });

--- a/tests/integration/components/sl-radio-group-test.js
+++ b/tests/integration/components/sl-radio-group-test.js
@@ -267,7 +267,7 @@ test( 'Default value gets selected by default', function( assert ) {
 test( 'Yielded content passes through', function( assert ) {
 
     this.render( hbs`
-        {{#sl-radio-group value=value name="testName"}}
+        {{#sl-radio-group name="testName"}}
             A content
         {{/sl-radio-group}}
     ` );


### PR DESCRIPTION
Closes softlayer/sl-ember-components#767: https://github.com/softlayer/sl-ember-components/issues/767

Added integration tests for: 
default rendered state
name properties
optional properties
required properties
label properties

Also, set the following properties to their default values in the component:
optional: false
required: false
label: null