### PR TITLE
Close issue #866 softlayer/sl-ember-components#866

### DIFF
--- a/tests/dummy/app/templates/demos/sl-date-range-picker.hbs
+++ b/tests/dummy/app/templates/demos/sl-date-range-picker.hbs
@@ -39,7 +39,7 @@
     {{/property-text}}
 
     {{#property-text name="format" type="String" default="\"mm/dd/yyyy\""}}
-        The date format used for both inpus; combination of d, dd, D, DD, m, mm, M, MM, yy, yyyy
+        The date format used for both inputs; combination of d, dd, D, DD, m, mm, M, MM, yy, yyyy
         <ul>
             <li>d, dd : Numeric date, no leading zero and leading zero, respectively</li>
             <li>D, DD : Abbreviated and full weekday names, respectively</li>


### PR DESCRIPTION
Fixed the typo 'inpus' in the sl-date-range-picker documentation

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/softlayer/sl-ember-components/1086)
<!-- Reviewable:end -->
