### PR TITLE
Added additional integration tests for sl-radio

### DIFF
--- a/addon/components/sl-radio.js
+++ b/addon/components/sl-radio.js
@@ -38,6 +38,13 @@ export default Ember.Component.extend( InputBased, {
     // Properties
 
     /**
+     * Whether to show the component in-line
+     *
+     * @type {Boolean}
+     */
+    inline: false,
+
+    /**
      * Text label for the component
      *
      * @type {?String}

--- a/tests/integration/components/sl-radio-test.js
+++ b/tests/integration/components/sl-radio-test.js
@@ -22,8 +22,9 @@ test( 'Default rendered state', function( assert ) {
         'Has class "radio"'
     );
 
-    assert.ok(
-        this.$( '>:first-child' ).find( 'input[type="radio"]' ),
+    assert.strictEqual(
+        this.$( '>:first-child' ).find( 'input[type="radio"]' ).length,
+        1,
         'input type is set to "radio"'
     );
 });

--- a/tests/integration/components/sl-radio-test.js
+++ b/tests/integration/components/sl-radio-test.js
@@ -77,18 +77,8 @@ test( 'name applies property to input', function( assert ) {
 });
 
 test( '"value" property is supported', function( assert ) {
-    this.render( defaultTemplate );
-
-    assert.strictEqual(
-        this.$( '>:first-child' ).find( 'input' ).val(),
-        'on',
-        'input value set to default value of "on"'
-    );
-
-    this.set( 'valueTest', 'testValue' );
-
     this.render( hbs`
-        {{sl-radio value=valueTest}}
+        {{sl-radio value="testValue"}}
     ` );
 
     assert.strictEqual(
@@ -99,18 +89,8 @@ test( '"value" property is supported', function( assert ) {
 });
 
 test( '"label" property is supported', function( assert ) {
-    this.render( defaultTemplate );
-
-    assert.strictEqual(
-        this.$( '>:first-child' ).find( 'label' ).text().trim(),
-        '',
-        '"label" text is not set'
-    );
-
-    this.set( 'labelTest', 'testLabel' );
-
     this.render( hbs`
-        {{sl-radio label=labelTest}}
+        {{sl-radio label="testLabel"}}
     ` );
 
     assert.strictEqual(

--- a/tests/integration/components/sl-radio-test.js
+++ b/tests/integration/components/sl-radio-test.js
@@ -1,14 +1,16 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
+const defaultTemplate = hbs`
+    {{sl-radio}}
+`;
+
 moduleForComponent( 'sl-radio', 'Integration | Component | sl radio', {
     integration: true
 });
 
 test( 'Default rendered state', function( assert ) {
-    this.render( hbs`
-        {{sl-radio}}
-    ` );
+    this.render( defaultTemplate );
 
     assert.ok(
         this.$( '>:first-child' ).hasClass( 'sl-radio' ),
@@ -54,9 +56,7 @@ test( 'Inline property sets relevant class', function( assert ) {
 });
 
 test( 'name applies property to input', function( assert ) {
-    this.render( hbs`
-        {{sl-radio}}
-    ` );
+    this.render( defaultTemplate );
 
     assert.strictEqual(
         this.$( '>:first-child' ).find( 'input' ).prop( 'name' ),
@@ -76,6 +76,14 @@ test( 'name applies property to input', function( assert ) {
 });
 
 test( '"value" property is supported', function( assert ) {
+    this.render( defaultTemplate );
+
+    assert.strictEqual(
+        this.$( '>:first-child' ).find( 'input' ).val(),
+        'on',
+        'input value set to default value of "on"'
+    );
+
     this.set( 'valueTest', 'testValue' );
 
     this.render( hbs`
@@ -85,11 +93,19 @@ test( '"value" property is supported', function( assert ) {
     assert.strictEqual(
         this.$( '>:first-child' ).find( 'input' ).val(),
         'testValue',
-        'input value gets set'
+        '"value" is set'
     );
 });
 
 test( '"label" property is supported', function( assert ) {
+    this.render( defaultTemplate );
+
+    assert.strictEqual(
+        this.$( '>:first-child' ).find( 'label' ).text().trim(),
+        '',
+        '"label" text is not set'
+    );
+
     this.set( 'labelTest', 'testLabel' );
 
     this.render( hbs`
@@ -99,6 +115,6 @@ test( '"label" property is supported', function( assert ) {
     assert.strictEqual(
         this.$( '>:first-child' ).find( 'label' ).text().trim(),
         'testLabel',
-        '"label" value gets set'
+        '"label" text gets set'
     );
 });

--- a/tests/integration/components/sl-radio-test.js
+++ b/tests/integration/components/sl-radio-test.js
@@ -5,6 +5,27 @@ moduleForComponent( 'sl-radio', 'Integration | Component | sl radio', {
     integration: true
 });
 
+test( 'Default rendered state', function( assert ) {
+    this.render( hbs`
+        {{sl-radio}}
+    ` );
+
+    assert.ok(
+        this.$( '>:first-child' ).hasClass( 'sl-radio' ),
+        'Has class "sl-radio"'
+    );
+
+    assert.ok(
+        this.$( '>:first-child' ).hasClass( 'radio' ),
+        'Has class "radio"'
+    );
+
+    assert.ok(
+        this.$( '>:first-child' ).find( 'input[type="radio"]' ),
+        'input type is set to "radio"'
+    );
+});
+
 test( 'Disabled state applies disabled class, and attribute to input', function( assert ) {
     this.render( hbs`
         {{sl-radio disabled=true}}
@@ -51,5 +72,33 @@ test( 'name applies property to input', function( assert ) {
         this.$( '>:first-child' ).find( 'input' ).prop( 'name' ),
         'testname',
         'Rendered input has name set'
+    );
+});
+
+test( '"value" property is supported', function( assert ) {
+    this.set( 'valueTest', 'testValue' );
+
+    this.render( hbs`
+        {{sl-radio value=valueTest}}
+    ` );
+
+    assert.strictEqual(
+        this.$( '>:first-child' ).find( 'input' ).val(),
+        'testValue',
+        'input value gets set'
+    );
+});
+
+test( '"label" property is supported', function( assert ) {
+    this.set( 'labelTest', 'testLabel' );
+
+    this.render( hbs`
+        {{sl-radio label=labelTest}}
+    ` );
+
+    assert.strictEqual(
+        this.$( '>:first-child' ).find( 'label' ).text().trim(),
+        'testLabel',
+        '"label" value gets set'
     );
 });


### PR DESCRIPTION
Closes softlayer/sl-ember-components#769

Added additional tests for:
default rendered state
label property
value property

Also added the property inline: false to the component since it was missing.

No tests were written for:
readonly property, since it is no longer part of this component
id is set to inputId, since it is no longer set in the template
name property, since the test was already written

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/softlayer/sl-ember-components/1087)
<!-- Reviewable:end -->
