### PR TITLE
fix changeDecade fn, computed prop ret null, Close #515 

### DIFF
--- a/addon/components/sl-calendar.js
+++ b/addon/components/sl-calendar.js
@@ -340,12 +340,6 @@ export default Ember.Component.extend({
     decadeEnd: Ember.computed(
         'decadeStart',
         function() {
-            const decadeStart = this.get( 'decadeStart' );
-
-            if ( !decadeStart ) {
-                return null;
-            }
-
             return this.get( 'decadeStart' ) + 9;
         }
     ),
@@ -360,10 +354,6 @@ export default Ember.Component.extend({
         'currentYear',
         function() {
             const currentYear = this.get( 'currentYear' );
-
-            if ( !currentYear ) {
-                return null;
-            }
 
             return currentYear - ( currentYear % 10 );
         }
@@ -411,8 +401,7 @@ export default Ember.Component.extend({
     shortWeekDayNames: Ember.computed(
         'locale',
         function() {
-            const locale = this.get( 'locale' ) || '';
-            const m = window.moment().locale( locale );
+            const m = window.moment().locale( this.get( 'locale' ) );
 
             return Ember.A([
                 m.day( 0 ).format( 'dd' ),

--- a/addon/components/sl-calendar.js
+++ b/addon/components/sl-calendar.js
@@ -411,8 +411,8 @@ export default Ember.Component.extend({
     shortWeekDayNames: Ember.computed(
         'locale',
         function() {
-            const locale = this.get( 'locale' ) || '',
-                  m = window.moment().locale( locale );
+            const locale = this.get( 'locale' ) || '';
+            const m = window.moment().locale( locale );
 
             return Ember.A([
                 m.day( 0 ).format( 'dd' ),

--- a/addon/components/sl-calendar.js
+++ b/addon/components/sl-calendar.js
@@ -46,7 +46,7 @@ export default Ember.Component.extend({
                 return;
             }
 
-            this.incrementProperty( 'decadeStart', 10 * decadeMod );
+            this.incrementProperty( 'currentYear', 10 * decadeMod );
         },
 
         /**
@@ -340,6 +340,12 @@ export default Ember.Component.extend({
     decadeEnd: Ember.computed(
         'decadeStart',
         function() {
+            const decadeStart = this.get( 'decadeStart' );
+
+            if ( !decadeStart ) {
+                return null;
+            }
+
             return this.get( 'decadeStart' ) + 9;
         }
     ),
@@ -354,6 +360,10 @@ export default Ember.Component.extend({
         'currentYear',
         function() {
             const currentYear = this.get( 'currentYear' );
+
+            if ( !currentYear ) {
+                return null;
+            }
 
             return currentYear - ( currentYear % 10 );
         }
@@ -401,7 +411,8 @@ export default Ember.Component.extend({
     shortWeekDayNames: Ember.computed(
         'locale',
         function() {
-            const m = window.moment().locale( this.get( 'locale' ) );
+            const locale = this.get( 'locale' ) || '',
+                  m = window.moment().locale( locale );
 
             return Ember.A([
                 m.day( 0 ).format( 'dd' ),


### PR DESCRIPTION
softlayer/sl-ember-components#515

Most computed properties do return proper default values. changed a few.

Also fixed the changeDecade function. incrementing the computed property makes it a normal property and causes a bug when changing decades.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/softlayer/sl-ember-components/1089)
<!-- Reviewable:end -->
