### PR TITLE
Sl calendar icons

### DIFF
--- a/addon/components/sl-calendar-day.js
+++ b/addon/components/sl-calendar-day.js
@@ -13,11 +13,17 @@ export default Ember.Component.extend({
     // -------------------------------------------------------------------------
     // Attributes
 
+    ariaRole: 'button',
+
+    attributeBindings: [
+        'tabindex'
+    ],
+
     /** @type {String[]} */
     classNameBindings: [
         'active',
         'new',
-        'old'
+        'old',
     ],
 
     /** @type {String[]} */
@@ -27,6 +33,8 @@ export default Ember.Component.extend({
 
     /** @type {Object} */
     layout,
+
+    tabindex: 0,
 
     /** @type {String} */
     tagName: 'td',

--- a/addon/components/sl-calendar-day.js
+++ b/addon/components/sl-calendar-day.js
@@ -17,7 +17,7 @@ export default Ember.Component.extend({
     classNameBindings: [
         'active',
         'new',
-        'old',
+        'old'
     ],
 
     /** @type {String[]} */

--- a/addon/components/sl-calendar-day.js
+++ b/addon/components/sl-calendar-day.js
@@ -13,12 +13,6 @@ export default Ember.Component.extend({
     // -------------------------------------------------------------------------
     // Attributes
 
-    ariaRole: 'button',
-
-    attributeBindings: [
-        'tabindex'
-    ],
-
     /** @type {String[]} */
     classNameBindings: [
         'active',
@@ -33,8 +27,6 @@ export default Ember.Component.extend({
 
     /** @type {Object} */
     layout,
-
-    tabindex: 0,
 
     /** @type {String} */
     tagName: 'td',

--- a/addon/components/sl-calendar.js
+++ b/addon/components/sl-calendar.js
@@ -20,7 +20,8 @@ export default Ember.Component.extend({
 
     /** @type {String[]} */
     classNames: [
-        'sl-calendar'
+        'sl-ember-components',
+        'calendar'
     ],
 
     /** @type {Object} */

--- a/addon/templates/components/sl-calendar.hbs
+++ b/addon/templates/components/sl-calendar.hbs
@@ -1,17 +1,17 @@
 <div class="datepicker datepicker-inline">
     {{#if viewingDays}}
-        <div class="datepicker-days" style="display: block;">
+        <div class="datepicker-days">
             <table class="table-condensed">
                 <thead>
                     <tr>
                         <th {{action "changeMonth" -1}} class="sl-icon-prev">
-                            <span class="sr-only">previous</span>
+                            previous month
                         </th>
-                        <th {{action "setView" "months"}} colspan="5" class="datepicker-switch">
+                        <th {{action "setView" "months"}} class="datepicker-switch" colspan="5">
                             {{currentMonthString}} {{currentYear}}
                         </th>
                         <th {{action "changeMonth" 1}} class="sl-icon-next">
-                            <span class="sr-only">next</span>
+                            next month
                         </th>
                     </tr>
                     <tr>
@@ -41,18 +41,18 @@
     {{/if}}
 
     {{#if viewingMonths}}
-        <div class="datepicker-months" style="display: block;">
+        <div class="datepicker-months">
             <table class="table-condensed">
                 <thead>
                     <tr>
-                        <th {{action "changeYear" -1}} class="sl-icon-prev" style="visibility: visible;">
-                            <span class="sr-only">previous</span>
+                        <th {{action "changeYear" -1}} class="sl-icon-prev">
+                            previous year
                         </th>
                         <th {{action "setView" "years"}} class="datepicker-switch" colspan="5">
                             {{currentYear}}
                         </th>
-                        <th {{action "changeYear" 1}} class="sl-icon-next" style="visibility: visible;">
-                            <span class="sr-only">next</span>
+                        <th {{action "changeYear" 1}} class="sl-icon-next">
+                            next year
                         </th>
                     </tr>
                 </thead>
@@ -75,18 +75,18 @@
     {{/if}}
 
     {{#if viewingYears}}
-        <div class="datepicker-years" style="display: block;">
+        <div class="datepicker-years">
             <table class="table-condensed">
                 <thead>
                     <tr>
-                        <th {{action "changeDecade" -1}} class="sl-icon-prev" style="visibility: visible;">
-                            <span class="sr-only">previous</span>
+                        <th {{action "changeDecade" -1}} class="sl-icon-prev">
+                            previous decade
                         </th>
                         <th class="datepicker-switch" colspan="5">
                             {{decadeStart}}-{{decadeEnd}}
                         </th>
-                        <th {{action "changeDecade" 1}} class="sl-icon-next" style="visibility: visible;">
-                            <span class="sr-only">next</span>
+                        <th {{action "changeDecade" 1}} class="sl-icon-next">
+                            next decade
                         </th>
                     </tr>
                 </thead>

--- a/addon/templates/components/sl-calendar.hbs
+++ b/addon/templates/components/sl-calendar.hbs
@@ -5,7 +5,7 @@
                 <thead>
                     <tr>
                         <th {{action "changeMonth" -1}} class="prev">
-                            <span class="fa fa-angle-left"></span>
+                            &#171;
                         </th>
                         <th
                             {{action "setView" "months"}}
@@ -15,7 +15,7 @@
                             {{currentMonthString}} {{currentYear}}
                         </th>
                         <th {{action "changeMonth" 1}} class="next">
-                            <span class="fa fa-angle-right"></span>
+                            &#187;
                         </th>
                     </tr>
                     <tr>
@@ -54,7 +54,7 @@
                             class="prev"
                             style="visibility: visible;"
                         >
-                            <span class="fa fa-angle-left"></span>
+                        &#171;
                         </th>
                         <th
                             {{action "setView" "years"}}
@@ -68,7 +68,7 @@
                             class="next"
                             style="visibility: visible;"
                         >
-                            <span class="fa fa-angle-right"></span>
+                            &#187;
                         </th>
                     </tr>
                 </thead>
@@ -97,7 +97,7 @@
                     <tr>
                         <th
                             {{action "changeDecade" -1}} class="prev" style="visibility: visible;">
-                            <span class="fa fa-angle-left"></span>
+                            &#171;
                         </th>
                         <th
                             class="datepicker-switch"
@@ -110,7 +110,7 @@
                             class="next"
                             style="visibility: visible;"
                         >
-                            <span class="fa fa-angle-right"></span>
+                        &#187;
                         </th>
                     </tr>
                 </thead>

--- a/addon/templates/components/sl-calendar.hbs
+++ b/addon/templates/components/sl-calendar.hbs
@@ -110,7 +110,7 @@
                             class="next"
                             style="visibility: visible;"
                         >
-                        &#187;
+                            &#187;
                         </th>
                     </tr>
                 </thead>

--- a/addon/templates/components/sl-calendar.hbs
+++ b/addon/templates/components/sl-calendar.hbs
@@ -4,18 +4,14 @@
             <table class="table-condensed">
                 <thead>
                     <tr>
-                        <th {{action "changeMonth" -1}} class="prev">
-                            &#171;
+                        <th {{action "changeMonth" -1}} class="sl-icon-prev">
+                            <span class="sr-only">previous</span>
                         </th>
-                        <th
-                            {{action "setView" "months"}}
-                            colspan="5"
-                            class="datepicker-switch"
-                        >
+                        <th {{action "setView" "months"}} colspan="5" class="datepicker-switch">
                             {{currentMonthString}} {{currentYear}}
                         </th>
-                        <th {{action "changeMonth" 1}} class="next">
-                            &#187;
+                        <th {{action "changeMonth" 1}} class="sl-icon-next">
+                            <span class="sr-only">next</span>
                         </th>
                     </tr>
                     <tr>
@@ -49,26 +45,14 @@
             <table class="table-condensed">
                 <thead>
                     <tr>
-                        <th
-                            {{action "changeYear" -1}}
-                            class="prev"
-                            style="visibility: visible;"
-                        >
-                        &#171;
+                        <th {{action "changeYear" -1}} class="sl-icon-prev" style="visibility: visible;">
+                            <span class="sr-only">previous</span>
                         </th>
-                        <th
-                            {{action "setView" "years"}}
-                            class="datepicker-switch"
-                            colspan="5"
-                        >
+                        <th {{action "setView" "years"}} class="datepicker-switch" colspan="5">
                             {{currentYear}}
                         </th>
-                        <th
-                            {{action "changeYear" 1}}
-                            class="next"
-                            style="visibility: visible;"
-                        >
-                            &#187;
+                        <th {{action "changeYear" 1}} class="sl-icon-next" style="visibility: visible;">
+                            <span class="sr-only">next</span>
                         </th>
                     </tr>
                 </thead>
@@ -95,22 +79,14 @@
             <table class="table-condensed">
                 <thead>
                     <tr>
-                        <th
-                            {{action "changeDecade" -1}} class="prev" style="visibility: visible;">
-                            &#171;
+                        <th {{action "changeDecade" -1}} class="sl-icon-prev" style="visibility: visible;">
+                            <span class="sr-only">previous</span>
                         </th>
-                        <th
-                            class="datepicker-switch"
-                            colspan="5"
-                        >
+                        <th class="datepicker-switch" colspan="5">
                             {{decadeStart}}-{{decadeEnd}}
                         </th>
-                        <th
-                            {{action "changeDecade" 1}}
-                            class="next"
-                            style="visibility: visible;"
-                        >
-                            &#187;
+                        <th {{action "changeDecade" 1}} class="sl-icon-next" style="visibility: visible;">
+                            <span class="sr-only">next</span>
                         </th>
                     </tr>
                 </thead>

--- a/addon/templates/components/sl-calendar.hbs
+++ b/addon/templates/components/sl-calendar.hbs
@@ -5,13 +5,13 @@
                 <thead>
                     <tr>
                         <th {{action "changeMonth" -1}} class="sl-icon-prev">
-                            previous month
+                            <span class="sr-only">previous month</span>
                         </th>
                         <th {{action "setView" "months"}} class="datepicker-switch" colspan="5">
                             {{currentMonthString}} {{currentYear}}
                         </th>
                         <th {{action "changeMonth" 1}} class="sl-icon-next">
-                            next month
+                            <span class="sr-only">next month</span>
                         </th>
                     </tr>
                     <tr>
@@ -46,13 +46,13 @@
                 <thead>
                     <tr>
                         <th {{action "changeYear" -1}} class="sl-icon-prev">
-                            previous year
+                            <span class="sr-only">previous year</span>
                         </th>
                         <th {{action "setView" "years"}} class="datepicker-switch" colspan="5">
                             {{currentYear}}
                         </th>
                         <th {{action "changeYear" 1}} class="sl-icon-next">
-                            next year
+                            <span class="sr-only">next year</span>
                         </th>
                     </tr>
                 </thead>
@@ -80,13 +80,13 @@
                 <thead>
                     <tr>
                         <th {{action "changeDecade" -1}} class="sl-icon-prev">
-                            previous decade
+                            <span class="sr-only">previous decade</span>
                         </th>
                         <th class="datepicker-switch" colspan="5">
                             {{decadeStart}}-{{decadeEnd}}
                         </th>
                         <th {{action "changeDecade" 1}} class="sl-icon-next">
-                            next decade
+                            <span class="sr-only">next decade</span>
                         </th>
                     </tr>
                 </thead>

--- a/app/styles/addon.less
+++ b/app/styles/addon.less
@@ -5,6 +5,7 @@
     line-height: 1;
     position: relative;
     top: 1px;
+    white-space: nowrap;
     display: inline-block;
     width: 1em;
     overflow: hidden;

--- a/app/styles/sl-calendar.less
+++ b/app/styles/sl-calendar.less
@@ -10,7 +10,7 @@
     }
 
     .sl-icon-next:before {
-       content: "»";
+        content: "»";
         .common-icon-properties
     }
 

--- a/app/styles/sl-calendar.less
+++ b/app/styles/sl-calendar.less
@@ -1,7 +1,7 @@
 .sl-ember-components.calendar {
     .common-icon-properties() {
         font-family: serif;
-        margin: 0;
+        margin-left: .4em;
     }
 
     .sl-icon-prev:before {
@@ -10,8 +10,14 @@
     }
 
     .sl-icon-next:before {
-        content: "»";
+       content: "»";
         .common-icon-properties
+    }
+
+    .datepicker-months,
+    .datepicker-days,
+    .datepicker-years {
+        display: block;
     }
 }
 

--- a/app/styles/sl-calendar.less
+++ b/app/styles/sl-calendar.less
@@ -1,0 +1,17 @@
+.sl-ember-components.calendar {
+    .common-icon-properties() {
+        font-family: serif;
+        margin: 0;
+    }
+
+    .sl-icon-prev:before {
+        content: "«";
+        .common-icon-properties
+    }
+
+    .sl-icon-next:before {
+        content: "»";
+        .common-icon-properties
+    }
+}
+

--- a/app/styles/sl-ember-components.less
+++ b/app/styles/sl-ember-components.less
@@ -21,6 +21,7 @@
 
 @import 'addon';
 @import 'sl-buttons';
+@import 'sl-calendar';
 @import 'sl-grid';
 @import 'sl-input';
 @import 'sl-loading-icon';

--- a/tests/integration/components/sl-calendar-test.js
+++ b/tests/integration/components/sl-calendar-test.js
@@ -40,8 +40,13 @@ test( 'Default rendered state', function( assert ) {
     ` );
 
     assert.ok(
-        this.$( '>:first-child' ).hasClass( 'sl-calendar' ),
-        'Has class "sl-calendar"'
+        this.$( '>:first-child' ).hasClass( 'sl-ember-components' ),
+        'Has class "sl-ember-components"'
+    );
+
+    assert.ok(
+        this.$( '>:first-child' ).hasClass( 'calendar' ),
+        'Has class "calendar"'
     );
 
     assert.ok(
@@ -527,7 +532,7 @@ test( 'Navigating Forward by Month', function( assert ) {
         'The current month is set correctly'
     );
 
-    this.$( '>:first-child' ).find( '.next' ).click();
+    this.$( '>:first-child' ).find( '.sl-icon-next' ).click();
 
     assert.strictEqual(
         this.$( '>:first-child' ).find( '.datepicker-switch' ).text().trim(),
@@ -556,7 +561,7 @@ test( 'Navigating Backward by Month', function( assert ) {
         'The current month is set correctly'
     );
 
-    this.$( '>:first-child' ).find( '.prev' ).click();
+    this.$( '>:first-child' ).find( '.sl-icon-prev' ).click();
 
     assert.strictEqual(
         this.$( '>:first-child' ).find( '.datepicker-switch' ).text().trim(),
@@ -583,7 +588,7 @@ test( 'Navigating Forward by Year', function( assert ) {
         'The current year is set correctly'
     );
 
-    this.$( '>:first-child' ).find( '.next' ).click();
+    this.$( '>:first-child' ).find( '.sl-icon-next' ).click();
 
     assert.strictEqual(
         this.$( '>:first-child' ).find( '.datepicker-switch' ).text().trim(),
@@ -610,7 +615,7 @@ test( 'Navigating Backward by Year', function( assert ) {
         'The current year is set correctly'
     );
 
-    this.$( '>:first-child' ).find( '.prev' ).click();
+    this.$( '>:first-child' ).find( '.sl-icon-prev' ).click();
 
     assert.strictEqual(
         this.$( '>:first-child' ).find( '.datepicker-switch' ).text().trim(),
@@ -636,7 +641,7 @@ test( 'Navigating Forward by Decade', function( assert ) {
         'The current Decade is set correctly'
     );
 
-    this.$( '>:first-child' ).find( '.next' ).click();
+    this.$( '>:first-child' ).find( '.sl-icon-next' ).click();
 
     assert.strictEqual(
         this.$( '>:first-child' ).find( '.datepicker-switch' ).text().trim(),
@@ -662,7 +667,7 @@ test( 'Navigating Backward by Decade', function( assert ) {
         'The current Decade is set correctly'
     );
 
-    this.$( '>:first-child' ).find( '.prev' ).click();
+    this.$( '>:first-child' ).find( '.sl-icon-prev' ).click();
 
     assert.strictEqual(
         this.$( '>:first-child' ).find( '.datepicker-switch' ).text().trim(),
@@ -707,7 +712,7 @@ test( 'When Locked, interacting with the view is not Possible', function( assert
         'The current month is set correctly'
     );
 
-    this.$( '>:first-child' ).find( '.next' ).click();
+    this.$( '>:first-child' ).find( '.sl-icon-next' ).click();
 
     assert.strictEqual(
         this.$( '>:first-child' ).find( '.datepicker-switch' ).text().trim(),
@@ -715,7 +720,7 @@ test( 'When Locked, interacting with the view is not Possible', function( assert
         'The next month is set correctly'
     );
 
-    this.$( '>:first-child' ).find( '.next' ).click();
+    this.$( '>:first-child' ).find( '.sl-icon-next' ).click();
 
     assert.strictEqual(
         this.$( '>:first-child' ).find( '.datepicker-switch' ).text().trim(),
@@ -871,7 +876,7 @@ test( 'Navigating Forward by Month Crosses to Next Year', function( assert ) {
         'The current month is set correctly'
     );
 
-    this.$( '>:first-child' ).find( '.next' ).click();
+    this.$( '>:first-child' ).find( '.sl-icon-next' ).click();
 
     assert.strictEqual(
         this.$( '>:first-child' ).find( '.datepicker-switch' ).text().trim(),
@@ -900,7 +905,7 @@ test( 'Navigating Backward by Month Crosses to Previous Year', function( assert 
         'The current month is set correctly'
     );
 
-    this.$( '>:first-child' ).find( '.prev' ).click();
+    this.$( '>:first-child' ).find( '.sl-icon-prev' ).click();
 
     assert.strictEqual(
         this.$( '>:first-child' ).find( '.datepicker-switch' ).text().trim(),
@@ -937,7 +942,7 @@ test( 'All Twelve Months are Displayed in Order', function( assert ) {
     ` );
 
     assert.strictEqual(
-        this.$( '>:first-child' ).find( 'span' ).text().trim(),
+        this.$( '>:first-child' ).find( 'span:not(.sr-only)' ).text().trim(),
         'JanFebMarAprMayJunJulAugSepOctNovDec',
         'Twelve months are listed in order'
     );
@@ -955,7 +960,7 @@ test( 'Twelve Years are Displayed in Order', function( assert ) {
     ` );
 
     assert.strictEqual(
-        this.$( '>:first-child' ).find( 'span' ).text().trim(),
+        this.$( '>:first-child' ).find( 'span:not(.sr-only)' ).text().trim(),
         '201920202021202220232024202520262027202820292030',
         'Twelve years are listed in order'
     );
@@ -1029,7 +1034,7 @@ test( 'Dual instance: Navigating Forward by Month', function( assert ) {
         }}
     ` );
 
-    this.$( '>:nth-child(2)' ).find( '.next' ).click();
+    this.$( '>:nth-child(2)' ).find( '.sl-icon-next' ).click();
 
     assert.strictEqual(
         this.$( '>:first-child' ).find( '.datepicker-switch' ).text().trim(),
@@ -1065,7 +1070,7 @@ test( 'Dual instance: Navigating Backward by Month', function( assert ) {
         }}
     ` );
 
-    this.$( '>:nth-child(2)' ).find( '.prev' ).click();
+    this.$( '>:nth-child(2)' ).find( '.sl-icon-prev' ).click();
 
     assert.strictEqual(
         this.$( '>:first-child' ).find( '.datepicker-switch' ).text().trim(),
@@ -1097,7 +1102,7 @@ test( 'Dual instance: Navigating Forward by Year', function( assert ) {
         }}
     ` );
 
-    this.$( '>:nth-child(2)' ).find( '.next' ).click();
+    this.$( '>:nth-child(2)' ).find( '.sl-icon-next' ).click();
 
     assert.strictEqual(
         this.$( '>:first-child' ).find( '.datepicker-switch' ).text().trim(),
@@ -1129,7 +1134,7 @@ test( 'Dual instance: Navigating Backward by Year', function( assert ) {
         }}
     ` );
 
-    this.$( '>:nth-child(2)' ).find( '.prev' ).click();
+    this.$( '>:nth-child(2)' ).find( '.sl-icon-prev' ).click();
 
     assert.strictEqual(
         this.$( '>:first-child' ).find( '.datepicker-switch' ).text().trim(),
@@ -1161,7 +1166,7 @@ test( 'Dual instance: Navigating Forward by Decade', function( assert ) {
         }}
     ` );
 
-    this.$( '>:nth-child(2)' ).find( '.next' ).click();
+    this.$( '>:nth-child(2)' ).find( '.sl-icon-next' ).click();
 
     assert.strictEqual(
         this.$( '>:first-child' ).find( '.datepicker-switch' ).text().trim(),
@@ -1193,7 +1198,7 @@ test( 'Dual instance: Navigating Backward by Decade', function( assert ) {
         }}
     ` );
 
-    this.$( '>:nth-child(2)' ).find( '.prev' ).click();
+    this.$( '>:nth-child(2)' ).find( '.sl-icon-prev' ).click();
 
     assert.strictEqual(
         this.$( '>:first-child' ).find( '.datepicker-switch' ).text().trim(),
@@ -1375,7 +1380,7 @@ test( 'Dual instance: Navigating Forward by Month Crosses to Next Year', functio
         }}
     ` );
 
-    this.$( '>:nth-child(2)' ).find( '.next' ).click();
+    this.$( '>:nth-child(2)' ).find( '.sl-icon-next' ).click();
 
     assert.strictEqual(
         this.$( '>:first-child' ).find( '.datepicker-switch' ).text().trim(),
@@ -1411,7 +1416,7 @@ test( 'Dual instance: Navigating Backward by Month Crosses to Previous Year', fu
         }}
     ` );
 
-    this.$( '>:nth-child(2)' ).find( '.prev' ).click();
+    this.$( '>:nth-child(2)' ).find( '.sl-icon-prev' ).click();
 
     assert.strictEqual(
         this.$( '>:first-child' ).find( '.datepicker-switch' ).text().trim(),

--- a/tests/integration/components/sl-calendar-test.js
+++ b/tests/integration/components/sl-calendar-test.js
@@ -71,7 +71,7 @@ test( 'sr-only class is set on child element when parent element has an icon cla
     ` );
 
     const getIcons = () => this.$( '>:first-child' ).find( '[class^="sl-icon-"]' );
-    const classIsPresent = ( element ) => Ember.$( element ).find( '.sr-only' ).length === 1;
+    const classIsPresent = ( element ) => 1 === Ember.$( element ).find( '.sr-only' ).length;
 
     assert.ok(
         getIcons().toArray().every( classIsPresent ),

--- a/tests/integration/components/sl-calendar-test.js
+++ b/tests/integration/components/sl-calendar-test.js
@@ -65,6 +65,34 @@ test( 'Default rendered state', function( assert ) {
     );
 });
 
+test( 'sr-only class is set on child element when parent element has an icon class', function( assert ) {
+    this.render( hbs`
+        {{sl-calendar}}
+    ` );
+
+    const getIcons = () => this.$( '>:first-child' ).find( '[class^="sl-icon-"]' );
+    const classIsPresent = ( element ) => Ember.$( element ).find( '.sr-only' ).length === 1;
+
+    assert.ok(
+        getIcons().toArray().every( classIsPresent ),
+        'sr-only class is present on month icons'
+    );
+
+    this.$( '.datepicker-switch' ).click();
+
+    assert.ok(
+        getIcons().toArray().every( classIsPresent ),
+        'sr-only class is present on year icons'
+    );
+
+    this.$( '.datepicker-switch' ).click();
+
+    assert.ok(
+        getIcons().toArray().every( classIsPresent ),
+        'sr-only class is present on decade icons'
+    );
+});
+
 test( 'Check for classes set on items outside of range in picker', function( assert ) {
     this.set( 'currentYear', 2015 );
     this.set( 'currentMonth', 1 );


### PR DESCRIPTION
Was initially able to use bootstrap glyphicons for next and previous. The problem we run into is that sl-datepicker ends up looking different because it does not use glyphicons. I tried to override sl-datepicker to use glyphicons but it ended up being a lot of CSS. 

I opted to make sl-calendar consistent with sl-datepicker by simply using the same htmlentities that sl-datepicker uses, instead of applying over 30 lines of CSS to override the sl-datepicker styles.




Closes https://github.com/softlayer/sl-ember-components/issues/1122

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/softlayer/sl-ember-components/1209)
<!-- Reviewable:end -->
