### PR TITLE
Closes softlayer/sl-ember-components#1228

### DIFF
--- a/tests/integration/components/sl-grid-cell-test.js
+++ b/tests/integration/components/sl-grid-cell-test.js
@@ -44,7 +44,7 @@ test( 'Primary column class is applied', function( assert ) {
 
     this.set( 'column', column );
     this.set( 'row', row );
-    
+
     this.render( defaultTemplate );
 
     assert.ok(

--- a/tests/integration/components/sl-grid-cell-test.js
+++ b/tests/integration/components/sl-grid-cell-test.js
@@ -16,15 +16,17 @@ const defaultRow = Ember.Object.extend({
 });
 
 const defaultTemplate = hbs`
-    {{sl-grid-cell column=column}}
+    {{sl-grid-cell column=column row=row}}
 `;
 
 test( 'Column alignment class is applied', function( assert ) {
     const column = defaultColumn.create({
         align: 'right'
     });
+    const row = defaultRow.create();
 
     this.set( 'column', column );
+    this.set( 'row', row );
     this.render( defaultTemplate );
 
     assert.ok(
@@ -37,8 +39,10 @@ test( 'Primary column class is applied', function( assert ) {
     const column = defaultColumn.create({
         primary: true
     });
+    const row = defaultRow.create();
 
     this.set( 'column', column );
+    this.set( 'row', row );
     this.render( defaultTemplate );
 
     assert.ok(

--- a/tests/integration/components/sl-grid-cell-test.js
+++ b/tests/integration/components/sl-grid-cell-test.js
@@ -27,6 +27,7 @@ test( 'Column alignment class is applied', function( assert ) {
 
     this.set( 'column', column );
     this.set( 'row', row );
+
     this.render( defaultTemplate );
 
     assert.ok(
@@ -43,6 +44,7 @@ test( 'Primary column class is applied', function( assert ) {
 
     this.set( 'column', column );
     this.set( 'row', row );
+    
     this.render( defaultTemplate );
 
     assert.ok(


### PR DESCRIPTION
We should maybe consider enforcing row as mandatory.  It is possible to check for row here:
https://github.com/softlayer/sl-ember-components/blob/EmberCli-1.13.8/addon/components/sl-grid-cell.js#L135
before doing the return to avoid the deprecation warnings (as it would get called with null), but that doesn't really fix the problem.  It seems row is a mandatory property and we should perhaps enforce that.

This pull request fixes the tests to not abuse the grid-cell by not passing a row.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/softlayer/sl-ember-components/1237)
<!-- Reviewable:end -->
