### PR TITLE
Create error architecture for sl-ember-components

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,36 @@ For more information on using ember-cli, visit [http://www.ember-cli.com/](http:
 
     ember install sl-ember-components
 
+## Error Handling
+
+The components in sl-ember-components will throw errors if the components are used incorrectly. For example, the `sl-radio-group` component requires that a `name` property be passed with the component. If one is not passed an error will be thrown with the name of the component that is throwing the error (sl-radio-group) and the message saying "The name property must be set".
+
+If you wish to capture these errors and pass them along to your error logging application you can do so by adding the following lines to your application's `app/app.js` file:
+
+```
+var App;
+
+...
+
+Ember.onerror = function( error ) {
+
+    if ( errorWasThrown( error ) ) {
+        //This will catch any errors coming from the sl-ember-components addon
+        //Insert the code you would use to send to your error logging application here
+    }
+
+    if ( isErrorInstanceOf( 'radioGroup' ) ) {
+        //Use this option if you want granularity at the individual component level
+        //Insert the code you would use to send to your error logging application here
+    }
+
+    ...Repeat the above for each component that you want to watch for where "radioGroup"
+    is the name of the component "sl-radio-group". So if you wanted to watch "sl-menu" you
+    would replace "radioGroup" with "menu".
+
+    console.error( error ); // Still send the error to the console
+};
+```
 
 ## Styling
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Provides Bootstrap tooltip functionality bindings, for both popovers and plain t
 
 Provides an abstraction between the events the *sl-menu* component listens for and the ability to associate any keyboard shortcuts in your application to trigger them.
 
+*error*
+
+Provides sl-ember-components a way for individual components to throw errors that are able to be recognized by methods inside of a comsuming applications `Ember.onerror()` function. For more details reference the [Error Handling](#error-handling) section below.
+
 
 ---
 
@@ -144,7 +148,7 @@ For more information on using ember-cli, visit [http://www.ember-cli.com/](http:
 
     ember install sl-ember-components
 
-## Error Handling
+## Error Handling ##
 
 The components in sl-ember-components will throw errors if the components are used incorrectly. For example, the `sl-radio-group` component requires that a `name` property be passed with the component. If one is not passed an error will be thrown with the name of the component that is throwing the error (sl-radio-group) and the message saying "The name property must be set".
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ The components in sl-ember-components will throw errors if the components are us
 If you wish to capture these errors and pass them along to your error logging application you can do so by adding the following lines to your application's `app/app.js` file:
 
 ```
+import { errorWasThrown, isErrorInstanceOf } from 'sl-ember-components/utils/error';
+
 var App;
 
 ...
@@ -158,18 +160,18 @@ var App;
 Ember.onerror = function( error ) {
 
     if ( errorWasThrown( error ) ) {
-        //This will catch any errors coming from the sl-ember-components addon
-        //Insert the code you would use to send to your error logging application here
+        // This will catch any errors coming from the sl-ember-components addon
+        // Insert the code you would use to send to your error logging application here
     }
 
     if ( isErrorInstanceOf( 'radioGroup' ) ) {
-        //Use this option if you want granularity at the individual component level
-        //Insert the code you would use to send to your error logging application here
+        // Use this option if you want granularity at the individual component level
+        // Insert the code you would use to send to your error logging application here
     }
 
     ...Repeat the above for each component that you want to watch for where "radioGroup"
     is the name of the component "sl-radio-group". So if you wanted to watch "sl-menu" you
-    would replace "radioGroup" with "menu".
+    would replace "radioGroup" with "menu". To see what can be used look at addon/utils/error.js.
 
     console.error( error ); // Still send the error to the console
 };

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Provides an abstraction between the events the *sl-menu* component listens for a
 
 *error*
 
-Provides sl-ember-components a way for individual components to throw errors that are able to be recognized by methods inside of a comsuming applications `Ember.onerror()` function. For more details reference the [Error Handling](#error-handling) section below.
+Provides a way for individual components to throw errors that are able to be recognized by methods inside of a consuming application's `Ember.onerror()` function. For more details reference the [Error Handling](#error-handling) section below.
 
 
 ---

--- a/addon/components/sl-chart.js
+++ b/addon/components/sl-chart.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/sl-chart';
+import { throwChartError } from '../utils/error';
 
 /**
  * @module
@@ -75,15 +76,15 @@ export default Ember.Component.extend({
      * Check passed parameters on initialization
      *
      * @function
-     * @throws {ember/Error} Series property must be an Array
-     * @throws {ember/Error} Options property must be an Object
+     * @throws {sl-ember-components/utils/error/chart} Series property must be an Array
+     * @throws {sl-ember-components/utils/error/chart} Options property must be an Object
      * @returns {undefined}
      */
     initialize: Ember.on(
         'init',
         function() {
             if ( 'array' !== Ember.typeOf( this.get( 'series' ) ) ) {
-                throw new Ember.Error( 'Series property must be an array' );
+                throwChartError( 'Series property must be an array' );
             }
 
             /* jshint ignore:start */
@@ -95,7 +96,7 @@ export default Ember.Component.extend({
                 ) ||
                 'symbol' === typeof options
             ) {
-                throw new Ember.Error( 'Options property must be an Object' );
+                throwChartError( 'Options property must be an Object' );
             }
             /* jshint ignore:end */
         }

--- a/addon/components/sl-date-time.js
+++ b/addon/components/sl-date-time.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import TooltipEnabled from '../mixins/sl-tooltip-enabled';
 import layout from '../templates/components/sl-date-time';
+import { throwDateTimeError } from '../utils/error';
 
 /**
  * Valid date format strings
@@ -100,21 +101,21 @@ export default Ember.Component.extend( TooltipEnabled, {
      * Check passed parameters on initialization
      *
      * @function
-     * @throws {ember/Error} timezone property must be a string
-     * @throws {ember/Error} timezone property provided is not valid
+     * @throws {sl-ember-components/utils/error/dateTime} timezone property must be a string
+     * @throws {sl-ember-components/utils/error/dateTime} timezone property provided is not valid
      * @returns {undefined}
      */
     initialize: Ember.on(
         'init',
         function() {
             if ( 'string' !== Ember.typeOf( this.get( 'timezone' ) ) ) {
-                throw new Ember.Error( 'timezone property must be a string' );
+                throwDateTimeError( 'Timezone property must be a string' );
             }
 
             const validTimeZonesArray = window.moment.tz.names();
 
             if ( !validTimeZonesArray.includes( this.get( 'timezone' ) ) ) {
-                throw new Ember.Error( 'timezone property provided is not valid' );
+                throwDateTimeError( 'Timezone property provided is not valid' );
             }
         }
     ),

--- a/addon/components/sl-menu.js
+++ b/addon/components/sl-menu.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import StreamEnabled from 'ember-stream/mixins/stream-enabled';
 import layout from '../templates/components/sl-menu';
 import { warn } from '../utils/all';
+import { throwMenuError } from '../utils/error';
 
 /**
  * @module
@@ -279,7 +280,7 @@ export default Ember.Component.extend( StreamEnabled, {
      *
      * @function
      * @param {Number} index - The index of the item to select
-     * @throws {ember/Error}
+     * @throws {sl-ember-components/utils/error/menu}
      * @returns {undefined}
      */
     select( index ) {
@@ -295,7 +296,7 @@ export default Ember.Component.extend( StreamEnabled, {
             const selection = selections.objectAt( selectionsLength - 1 );
 
             if ( !selection ) {
-                throw new Ember.Error( 'Current selection is undefined' );
+                throwMenuError( 'Current selection is undefined' );
             }
 
             const contextItems = selectionsLength > 1 ?
@@ -305,7 +306,7 @@ export default Ember.Component.extend( StreamEnabled, {
             const currentItem = Ember.get( selection, 'item' );
 
             if ( !currentItem ) {
-                throw new Ember.Error( 'Current item is undefined' );
+                throwMenuError( 'Current item is undefined' );
             }
 
             item = contextItems.objectAt( index );
@@ -321,7 +322,7 @@ export default Ember.Component.extend( StreamEnabled, {
             const items = this.get( 'items' );
 
             if ( !items ) {
-                throw new Ember.Error( 'Component `items` is undefined' );
+                throwMenuError( 'Component `items` is undefined' );
             }
 
             if ( items.length > 0 && index < items.length ) {
@@ -380,7 +381,7 @@ export default Ember.Component.extend( StreamEnabled, {
      * Select the next sibling in the current context
      *
      * @function
-     * @throws {ember/Error}
+     * @throws {sl-ember-components/utils/error/menu}
      * @returns {undefined}
      */
     selectNext() {
@@ -400,13 +401,13 @@ export default Ember.Component.extend( StreamEnabled, {
         const currentItems = Ember.get( selection, 'items' );
 
         if ( !currentItems ) {
-            throw new Ember.Error( 'Current selection items are undefined' );
+            throwMenuError( 'Current selection items are undefined' );
         }
 
         const currentIndex = Ember.get( selection, 'index' );
 
         if ( 'number' !== Ember.typeOf( currentIndex ) ) {
-            throw new Ember.Error( 'Current index is not valid' );
+            throwMenuError( 'Current index is not valid' );
         }
 
         // Select the "show all" option if we're on the last context item at the
@@ -424,7 +425,7 @@ export default Ember.Component.extend( StreamEnabled, {
         const currentItem = Ember.get( selection, 'item' );
 
         if ( !currentItem ) {
-            throw new Ember.Error( 'Current item is undefined' );
+            throwMenuError( 'Current item is undefined' );
         }
 
         let newIndex = currentIndex + 1;
@@ -436,7 +437,7 @@ export default Ember.Component.extend( StreamEnabled, {
         const item = currentItems[ newIndex ];
 
         if ( !item ) {
-            throw new Ember.Error( `Item with index ${newIndex} is undefined` );
+            throwMenuError( `Item with index ${newIndex} is undefined` );
         }
 
         Ember.set( currentItem, 'selected', false );
@@ -452,7 +453,7 @@ export default Ember.Component.extend( StreamEnabled, {
      * Select the parent menu from the current context
      *
      * @function
-     * @throws {ember/Error}
+     * @throws {sl-ember-components/utils/error/menu}
      * @returns {undefined}
      */
     selectParent() {
@@ -465,7 +466,7 @@ export default Ember.Component.extend( StreamEnabled, {
         const currentItem = Ember.get( selections.popObject(), 'item' );
 
         if ( !currentItem ) {
-            throw new Ember.Error( 'Invalid last menu item' );
+            throwMenuError( 'Invalid last menu item' );
         }
 
         Ember.set( currentItem, 'selected', false );
@@ -475,7 +476,7 @@ export default Ember.Component.extend( StreamEnabled, {
      * Select the previous sibling in the current context
      *
      * @function
-     * @throws {ember/Error}
+     * @throws {sl-ember-components/utils/error/menu}
      * @returns {undefined}
      */
     selectPrevious() {
@@ -499,7 +500,7 @@ export default Ember.Component.extend( StreamEnabled, {
         const currentItems = Ember.get( selection, 'items' );
 
         if ( !currentItems ) {
-            throw new Ember.Error( 'Current items are undefined' );
+            throwMenuError( 'Current items are undefined' );
         }
 
         // Select the "show all" option when at the beginning of the top-level
@@ -522,13 +523,13 @@ export default Ember.Component.extend( StreamEnabled, {
         const currentIndex = Ember.get( selection, 'index' );
 
         if ( 'number' !== Ember.typeOf( currentIndex ) ) {
-            throw new Ember.Error( 'Current index is not valid' );
+            throwMenuError( 'Current index is not valid' );
         }
 
         const currentItem = Ember.get( selection, 'item' );
 
         if ( !currentItem ) {
-            throw new Ember.Error( 'Current item is undefined' );
+            throwMenuError( 'Current item is undefined' );
         }
 
         let newIndex = currentIndex - 1;
@@ -540,7 +541,7 @@ export default Ember.Component.extend( StreamEnabled, {
         const item = currentItems[ newIndex ];
 
         if ( !item ) {
-            throw new Ember.Error( `Item with index ${newIndex} is undefined` );
+            throwMenuError( `Item with index ${newIndex} is undefined` );
         }
 
         Ember.set( currentItem, 'selected', false );
@@ -561,7 +562,6 @@ export default Ember.Component.extend( StreamEnabled, {
      * it has one.
      *
      * @function
-     * @throws {ember/Error}
      * @returns {undefined}
      */
     selectRight() {
@@ -578,7 +578,7 @@ export default Ember.Component.extend( StreamEnabled, {
      * Select the sub-menu in the current context
      *
      * @function
-     * @throws {ember/Error}
+     * @throws {sl-ember-components/utils/error/menu}
      * @returns {undefined}
      */
     selectSubMenu() {
@@ -591,13 +591,13 @@ export default Ember.Component.extend( StreamEnabled, {
         const selection = selections.get( selections.length - 1 );
 
         if ( !selection ) {
-            throw new Ember.Error( 'Last item of `selection` is invalid' );
+            throwMenuError( 'Last item of `selection` is invalid' );
         }
 
         const currentItem = Ember.get( selection, 'item' );
 
         if ( !currentItem ) {
-            throw new Ember.Error( 'Last selection menu item is invalid' );
+            throwMenuError( 'Last selection menu item is invalid' );
         }
 
         const items = Ember.get( currentItem, 'items' );
@@ -610,7 +610,7 @@ export default Ember.Component.extend( StreamEnabled, {
         const item = items[ index ];
 
         if ( !item ) {
-            throw new Ember.Error( 'First item in selected sub-menu is undefined' );
+            throwMenuError( 'First item in selected sub-menu is undefined' );
         }
 
         Ember.set( item, 'selected', true );
@@ -632,7 +632,6 @@ export default Ember.Component.extend( StreamEnabled, {
      * sibling menu item.
      *
      * @function
-     * @throws {ember/Error}
      * @returns {undefined}
      */
     selectUp() {

--- a/addon/components/sl-radio-group.js
+++ b/addon/components/sl-radio-group.js
@@ -3,6 +3,7 @@ import InputBased from '../mixins/sl-input-based';
 import TooltipEnabled from '../mixins/sl-tooltip-enabled';
 import layout from '../templates/components/sl-radio-group';
 import Namespace from '../mixins/sl-namespace';
+import { throwRadioGroupError } from '../utils/error';
 
 /**
  * @module
@@ -78,7 +79,7 @@ export default Ember.Component.extend( InputBased, TooltipEnabled, Namespace, {
      * Initialize the group-wide options and setup child radio buttons
      *
      * @function
-     * @throws {ember/Error} Thrown if the `name` property is not set
+     * @throws {sl-ember-components/utils/error/radioGroup} Thrown if the `name` property is not set
      * @returns {undefined}
      */
     initialize: Ember.on(
@@ -87,9 +88,7 @@ export default Ember.Component.extend( InputBased, TooltipEnabled, Namespace, {
             const name = this.get( 'name' );
 
             if ( Ember.isEmpty( name ) ) {
-                throw new Ember.Error(
-                    'The name property must be set on the sl-radio-group component'
-                );
+                throwRadioGroupError( 'The name property must be set' );
             }
 
             const value = this.get( 'value' );

--- a/addon/components/sl-tooltip.js
+++ b/addon/components/sl-tooltip.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import TooltipEnabled from '../mixins/sl-tooltip-enabled';
+import { throwTooltipError } from '../utils/error';
 
 /**
  * @module
@@ -33,21 +34,21 @@ export default Ember.Component.extend( TooltipEnabled, {
      * Check passed parameters on initialization
      *
      * @function
-     * @throws {ember/Error} Thrown if 'title' or 'popover' is invalid
+     * @throws {sl-ember-components/utils/error/tooltip} Thrown if 'title' or 'popover' is invalid
      * @returns {undefined}
      */
     initialize: Ember.on(
         'init',
         function() {
             if ( 'string' !== Ember.typeOf( this.get( 'title' ) ) ) {
-                throw new Ember.Error(
+                throwTooltipError(
                     'enableTooltip() and enablePopover() expect the parameter "title" and for it to be a string'
                 );
             }
 
             if ( 'string' !== Ember.typeOf( this.get( 'popover' ) ) &&
                  'undefined' !== Ember.typeOf( this.get( 'popover' ) ) ) {
-                throw new Ember.Error(
+                throwTooltipError(
                     'enablePopover() expects the parameter "popover" and for it to be a string'
                 );
             }

--- a/addon/utils/error.js
+++ b/addon/utils/error.js
@@ -1,0 +1,188 @@
+/* jshint ignore:start */
+
+import Ember from 'ember';
+
+/**
+ * @module
+ * @augments Error
+ */
+
+/** @type {String} */
+let errorTypeThrown = null;
+
+/**
+ * Creates an Error Function with additional values set
+ *
+ * @function
+ * @param {String} component The component name which needs an error function created
+ * @param {String} message The error message
+ * @returns {Function}
+ */
+const buildErrorFunction = function( component, message ) {
+    message = message || '';
+
+    const error = {};
+    const functionName = Ember.String.camelize( component.slice( 2 ) );
+    const createdFunction = new Function(
+        'return function ' + functionName + '() {' +
+            'this.name = "' + component + '";' +
+            'this.message = "' + message + '";' +
+        '};'
+    )();
+
+    error[ functionName ] = createdFunction;
+    error[ functionName ].prototype = Object.create( Error.prototype );
+    error[ functionName ].prototype.constructor = error[ functionName ];
+
+    setErrorTypeThrown( functionName );
+
+    return error[ functionName ];
+};
+
+/**
+ * Determines whether an error was thrown from sl-ember-components
+ *
+ * @function
+ * @returns {Boolean}
+ */
+const errorWasThrown = function() {
+    return !Ember.isEmpty( errorTypeThrown );
+};
+
+/**
+ * Determines whether an error instance was one defined from sl-ember-components
+ *
+ * @function
+ * @param {String} type The error instance's name to compare
+ * @returns {Boolean}
+ */
+const isErrorInstanceOf = function( type ) {
+    return type === errorTypeThrown;
+};
+
+/**
+ * Sets errorTypeThrown to the passed function name
+ *
+ * @function
+ * @param {String} functionName The error instance's name
+ * @returns {undefined}
+ */
+const setErrorTypeThrown = function( functionName ) {
+    errorTypeThrown = functionName;
+};
+
+/**
+ * Requests one of the sl-ember-component error functions to be created and throws that error
+ *
+ * @function
+ * @param {String} component The component name which needs an error function created
+ * @param {String} message The error message
+ * @returns {undefined}
+ */
+const throwError = function( component, message ) {
+    const ErrorFunction = buildErrorFunction( component, message );
+
+    throw new ErrorFunction();
+};
+
+
+/**
+ * @typedef chart
+ * @type {Error}
+ * @property {String} name - the component error name
+ * @property {String} message - the component error message
+ */
+
+/**
+ * Requests an sl-ember-component sl-chart error to be thrown
+ *
+ * @function
+ * @param {String} message The error message
+ * @returns {chart}
+ */
+const throwChartError = function( message ) {
+    throwError( 'sl-chart', message );
+};
+
+/**
+ * @typedef dateTime
+ * @type {Error}
+ * @property {String} name - the component error name
+ * @property {String} message - the component error message
+ */
+
+/**
+ * Requests an sl-ember-component sl-date-time error to be thrown
+ *
+ * @function
+ * @param {String} message The error message
+ * @returns {dateTime}
+ */
+const throwDateTimeError = function( message ) {
+    throwError( 'sl-date-time', message );
+};
+
+/**
+ * @typedef menu
+ * @type {Error}
+ * @property {String} name - the component error name
+ * @property {String} message - the component error message
+ */
+
+/**
+ * Requests an sl-ember-component sl-menu error to be thrown
+ *
+ * @function
+ * @param {String} message The error message
+ * @returns {menu}
+ */
+const throwMenuError = function( message ) {
+    throwError( 'sl-menu', message );
+};
+
+/**
+ * @typedef radioGroup
+ * @type {Error}
+ * @property {String} name - the component error name
+ * @property {String} message - the component error message
+ */
+
+/**
+ * Requests an sl-ember-component sl-radio-group error to be thrown
+ *
+ * @function
+ * @param {String} message The error message
+ * @returns {radioGroup}
+ */
+const throwRadioGroupError = function( message ) {
+    throwError( 'sl-radio-group', message );
+};
+
+/**
+ * @typedef tooltip
+ * @type {Error}
+ * @property {String} name - the component error name
+ * @property {String} message - the component error message
+ */
+
+/**
+ * Requests an sl-ember-component sl-tooltip error to be thrown
+ *
+ * @function
+ * @param {String} message The error message
+ * @returns {module:addon/utils/error~tooltip}
+ */
+const throwTooltipError = function( message ) {
+    throwError( 'sl-tooltip', message );
+};
+
+export {
+    errorWasThrown,
+    isErrorInstanceOf,
+    setErrorTypeThrown,
+    throwChartError,
+    throwDateTimeError,
+    throwMenuError,
+    throwRadioGroupError,
+    throwTooltipError
+};

--- a/addon/utils/error.js
+++ b/addon/utils/error.js
@@ -13,7 +13,6 @@ let errorTypeThrown = null;
 /**
  * Creates an Error Function with additional values set
  *
- * @function
  * @param {String} component The component name which needs an error function created
  * @param {String} message The error message
  * @returns {Function}
@@ -42,7 +41,6 @@ const buildErrorFunction = function( component, message ) {
 /**
  * Determines whether an error was thrown from sl-ember-components
  *
- * @function
  * @returns {Boolean}
  */
 const errorWasThrown = function() {
@@ -52,7 +50,6 @@ const errorWasThrown = function() {
 /**
  * Determines whether an error instance was one defined from sl-ember-components
  *
- * @function
  * @param {String} type The error instance's name to compare
  * @returns {Boolean}
  */
@@ -63,7 +60,6 @@ const isErrorInstanceOf = function( type ) {
 /**
  * Sets errorTypeThrown to the passed function name
  *
- * @function
  * @param {String} functionName The error instance's name
  * @returns {undefined}
  */
@@ -74,7 +70,6 @@ const setErrorTypeThrown = function( functionName ) {
 /**
  * Requests one of the sl-ember-component error functions to be created and throws that error
  *
- * @function
  * @param {String} component The component name which needs an error function created
  * @param {String} message The error message
  * @returns {undefined}
@@ -84,7 +79,6 @@ const throwError = function( component, message ) {
 
     throw new ErrorFunction();
 };
-
 
 /**
  * @typedef chart
@@ -96,7 +90,6 @@ const throwError = function( component, message ) {
 /**
  * Requests an sl-ember-component sl-chart error to be thrown
  *
- * @function
  * @param {String} message The error message
  * @returns {chart}
  */
@@ -114,7 +107,6 @@ const throwChartError = function( message ) {
 /**
  * Requests an sl-ember-component sl-date-time error to be thrown
  *
- * @function
  * @param {String} message The error message
  * @returns {dateTime}
  */
@@ -132,7 +124,6 @@ const throwDateTimeError = function( message ) {
 /**
  * Requests an sl-ember-component sl-menu error to be thrown
  *
- * @function
  * @param {String} message The error message
  * @returns {menu}
  */
@@ -150,7 +141,6 @@ const throwMenuError = function( message ) {
 /**
  * Requests an sl-ember-component sl-radio-group error to be thrown
  *
- * @function
  * @param {String} message The error message
  * @returns {radioGroup}
  */
@@ -168,9 +158,8 @@ const throwRadioGroupError = function( message ) {
 /**
  * Requests an sl-ember-component sl-tooltip error to be thrown
  *
- * @function
  * @param {String} message The error message
- * @returns {module:addon/utils/error~tooltip}
+ * @returns {tooltip}
  */
 const throwTooltipError = function( message ) {
     throwError( 'sl-tooltip', message );

--- a/tests/unit/utils/error-test.js
+++ b/tests/unit/utils/error-test.js
@@ -1,0 +1,200 @@
+import {
+    errorWasThrown,
+    isErrorInstanceOf,
+    setErrorTypeThrown,
+    throwChartError,
+    throwDateTimeError,
+    throwMenuError,
+    throwRadioGroupError,
+    throwTooltipError
+} from 'sl-ember-components/utils/error';
+import { module, test } from 'qunit';
+
+module( 'Unit | Utility | error', {
+    beforeEach() {
+        setErrorTypeThrown( null );
+    }
+});
+
+test( 'errorWasThrown() returns false when "errorTypeThrown" is not set', function( assert ) {
+
+    assert.strictEqual(
+        errorWasThrown(),
+        false,
+        'errorWasThrown() returns correct result when "errorTypeThrown" is not set'
+    );
+});
+
+test( 'isErrorInstanceOf() returns false when "errorTypeThrown" is null', function( assert ) {
+
+    assert.strictEqual(
+        isErrorInstanceOf( 'chart' ),
+        false,
+        'isErrorInstanceOf() returns correct result when "errorTypeThrown" uses default value'
+    );
+});
+
+test( 'errorWasThrown() returns true when "errorTypeThrown" is set', function( assert ) {
+    assert.expect( 1 );
+
+    try {
+        throwChartError( 'This is a test' );
+    } catch ( error ) {
+
+        assert.strictEqual(
+            errorWasThrown(),
+            true,
+            'errorWasThrown() returns correct result when "errorTypeThrown" is set'
+        );
+    }
+});
+
+test( 'isErrorInstanceOf() returns true when "errorTypeThrown" equals the error thrown', function( assert ) {
+    assert.expect( 1 );
+
+    try {
+        throwChartError( 'This is a test' );
+    } catch ( error ) {
+
+        assert.strictEqual(
+            isErrorInstanceOf( 'chart' ),
+            true,
+            'isErrorInstanceOf() returns correct result when "errorTypeThrown" is set'
+        );
+    }
+});
+
+test( 'isErrorInstanceOf() returns false when "errorTypeThrown" is not equivalent', function( assert ) {
+    assert.expect( 1 );
+
+    try {
+        throwDateTimeError( 'This is a test' );
+    } catch ( error ) {
+
+        assert.strictEqual(
+            isErrorInstanceOf( 'chart' ),
+            false,
+            'isErrorInstanceOf() returns correct result when "errorTypeThrown" is not set'
+        );
+    }
+});
+
+test( 'throwChartError() sets attributes on chart error', function( assert ) {
+    assert.expect( 2 );
+
+    try {
+        throwChartError( 'This is a test' );
+    } catch ( error ) {
+
+        assert.strictEqual(
+            error.name,
+            'sl-chart',
+            'throwChartError() returns an instance with name set correctly'
+        );
+
+        assert.strictEqual(
+            error.message,
+            'This is a test',
+            'throwChartError() returns an instance with message set correctly'
+        );
+    }
+});
+
+test( 'throwDateTimeError() sets attributes on dateTime error', function( assert ) {
+    assert.expect( 2 );
+
+    try {
+        throwDateTimeError( 'This is a test' );
+    } catch ( error ) {
+
+        assert.strictEqual(
+            error.name,
+            'sl-date-time',
+            'throwDateTimeError() returns an instance with name set correctly'
+        );
+
+        assert.strictEqual(
+            error.message,
+            'This is a test',
+            'throwDateTimeError() returns an instance with message set correctly'
+        );
+    }
+});
+
+test( 'throwMenuError() sets attributes on menu error', function( assert ) {
+    assert.expect( 2 );
+
+    try {
+        throwMenuError( 'This is a test' );
+    } catch ( error ) {
+
+        assert.strictEqual(
+            error.name,
+            'sl-menu',
+            'throwMenuError() returns an instance with name set correctly'
+        );
+
+        assert.strictEqual(
+            error.message,
+            'This is a test',
+            'throwMenuError() returns an instance with message set correctly'
+        );
+    }
+});
+
+test( 'throwRadioGroupError() sets attributes on radioGroup error', function( assert ) {
+    assert.expect( 2 );
+
+    try {
+        throwRadioGroupError( 'This is a test' );
+    } catch ( error ) {
+
+        assert.strictEqual(
+            error.name,
+            'sl-radio-group',
+            'throwRadioGroupError() returns an instance with name set correctly'
+        );
+
+        assert.strictEqual(
+            error.message,
+            'This is a test',
+            'throwRadioGroupError() returns an instance with message set correctly'
+        );
+    }
+});
+
+test( 'throwTooltipError() sets attributes on tooltip error', function( assert ) {
+    assert.expect( 2 );
+
+    try {
+        throwTooltipError( 'This is a test' );
+    } catch ( error ) {
+
+        assert.strictEqual(
+            error.name,
+            'sl-tooltip',
+            'throwTooltipError() returns an instance with name set correctly'
+        );
+
+        assert.strictEqual(
+            error.message,
+            'This is a test',
+            'throwTooltipError() returns an instance with message set correctly'
+        );
+    }
+});
+
+test( 'buildErrorFunction() sets message to empty string when message is not provided', function( assert ) {
+    assert.expect( 1 );
+
+    try {
+        throwTooltipError();
+    } catch ( error ) {
+
+        assert.strictEqual(
+            error.message,
+            '',
+            'buildErrorFunction() returns an instance with message set to empty string'
+        );
+    }
+});


### PR DESCRIPTION
Closes softlayer/sl-ember-components#1350

Created the error architecture for sl-ember-components and updated:
  sl-chart
  sl-date-time
  sl-menu
  sl-radio-group
  sl-tooltip 
to use the new error architecture.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/softlayer/sl-ember-components/1351)
<!-- Reviewable:end -->
