### PR TITLE
Remove use of assert.async() in integration test

### DIFF
--- a/tests/integration/components/sl-date-picker-test.js
+++ b/tests/integration/components/sl-date-picker-test.js
@@ -179,14 +179,10 @@ test( 'placeholder is accepted as a parameter', function( assert ) {
 test( 'action is fired when date changes on datepicker', function( assert ) {
     assert.expect( 1 );
 
-    const done = assert.async();
-
     this.on( 'action', function() {
         assert.ok(
             'Action was fired'
         );
-
-        done();
     });
 
     this.render( hbs`


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/softlayer/sl-ember-components/1357)
<!-- Reviewable:end -->
