### PR TITLE
Remove use of assert.async() in integration test 

### DIFF
--- a/tests/unit/components/sl-input-test.js
+++ b/tests/unit/components/sl-input-test.js
@@ -116,8 +116,6 @@ test( 'Event handlers are registered and unregistered', function( assert ) {
 test( 'Blur action is triggered when input loses focus', function( assert ) {
     assert.expect( 1 );
 
-    const done = assert.async();
-
     this.subject({
         blur: 'blur',
         targetObject: {
@@ -125,8 +123,6 @@ test( 'Blur action is triggered when input loses focus', function( assert ) {
                 assert.ok(
                     'blur was triggered'
                 );
-
-                done();
             }
         }
     });


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/softlayer/sl-ember-components/1358)
<!-- Reviewable:end -->
