### PR TITLE
fixed a missed 'prev' being converted to 'previous'. Removed icon mix…

### DIFF
--- a/app/styles/sl-calendar.less
+++ b/app/styles/sl-calendar.less
@@ -1,5 +1,5 @@
 .sl-ember-components.calendar {
-    .sl-icon-prev::before {
+    .sl-icon-previous::before {
         content: @icon-calendar-previous;
     }
 

--- a/app/styles/sl-date-picker.less
+++ b/app/styles/sl-date-picker.less
@@ -24,11 +24,3 @@
         content: @icon-date-picker-next;
     }
 }
-
-.datepicker thead th.prev {
-    &:extend(.sl-ember-components-icons all);
-}
-
-.datepicker thead th.next {
-    &:extend(.sl-ember-components-icons all);
-}


### PR DESCRIPTION
…in calls from datepicker since it is a hacked solution based on generated dom structure right now.

emergency fix

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/softlayer/sl-ember-components/1428)
<!-- Reviewable:end -->
