### PR TITLE
Updated demo app documentation with CSS namespacing information

### DIFF
--- a/tests/dummy/app/templates/demos/sl-alert.hbs
+++ b/tests/dummy/app/templates/demos/sl-alert.hbs
@@ -75,6 +75,17 @@
 
 <hr>
 
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-alert</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-alert.</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>Properties</h3>
 
 <div class="list-group">

--- a/tests/dummy/app/templates/demos/sl-alert.hbs
+++ b/tests/dummy/app/templates/demos/sl-alert.hbs
@@ -75,12 +75,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-alert</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-alert.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-alert.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-button.hbs
+++ b/tests/dummy/app/templates/demos/sl-button.hbs
@@ -125,12 +125,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-button</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-button.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-button.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-button.hbs
+++ b/tests/dummy/app/templates/demos/sl-button.hbs
@@ -125,6 +125,17 @@
 
 <hr>
 
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-button</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-button.</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>Properties</h3>
 
 <div class="list-group">

--- a/tests/dummy/app/templates/demos/sl-calendar.hbs
+++ b/tests/dummy/app/templates/demos/sl-calendar.hbs
@@ -27,12 +27,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-calendar</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-calendar.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-calendar.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-calendar.hbs
+++ b/tests/dummy/app/templates/demos/sl-calendar.hbs
@@ -27,6 +27,17 @@
 
 <hr>
 
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-calendar</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-calendar.</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>Properties</h3>
 
 <div class="list-group">

--- a/tests/dummy/app/templates/demos/sl-chart.hbs
+++ b/tests/dummy/app/templates/demos/sl-chart.hbs
@@ -53,12 +53,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-chart</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-chart.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-chart.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-chart.hbs
+++ b/tests/dummy/app/templates/demos/sl-chart.hbs
@@ -53,6 +53,17 @@
 
 <hr>
 
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-chart</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-chart.</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>Properties</h3>
 
 <div class="list-group">

--- a/tests/dummy/app/templates/demos/sl-checkbox.hbs
+++ b/tests/dummy/app/templates/demos/sl-checkbox.hbs
@@ -48,7 +48,20 @@
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-input-based</p>
+    </div>
+    <div class="list-group-item">
         <p>sl-tooltip-enabled</p>
+    </div>
+</div>
+
+<hr>
+
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-checkbox</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-checkbox.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-checkbox.hbs
+++ b/tests/dummy/app/templates/demos/sl-checkbox.hbs
@@ -56,12 +56,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-checkbox</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-checkbox.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-checkbox.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-date-picker.hbs
+++ b/tests/dummy/app/templates/demos/sl-date-picker.hbs
@@ -32,12 +32,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-date-picker</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-date-picker.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-date-picker.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-date-picker.hbs
+++ b/tests/dummy/app/templates/demos/sl-date-picker.hbs
@@ -25,15 +25,19 @@
     <div class="list-group-item">
         <p>sl-tooltip-enabled</p>
     </div>
+    <div class="list-group-item">
+        <p>sl-component-input-id</p>
+    </div>
 </div>
 
 <hr>
 
-<h3>Mixins used</h3>
+<h3>CSS Namespacing</h3>
 
 <div class="list-group">
     <div class="list-group-item">
-        <p>sl-component-input-id</p>
+        <p>sl-ember-components-date-picker</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-date-picker.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-date-range-picker.hbs
+++ b/tests/dummy/app/templates/demos/sl-date-range-picker.hbs
@@ -37,12 +37,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-date-range-picker</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-date-range-picker.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-date-range-picker.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-date-range-picker.hbs
+++ b/tests/dummy/app/templates/demos/sl-date-range-picker.hbs
@@ -37,6 +37,17 @@
 
 <hr>
 
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-date-range-picker</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-date-range-picker.</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>Properties</h3>
 
 <div class="list-group">

--- a/tests/dummy/app/templates/demos/sl-date-time.hbs
+++ b/tests/dummy/app/templates/demos/sl-date-time.hbs
@@ -67,6 +67,19 @@
     </div>
 </div>
 
+<hr>
+
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-date-time</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-date-time.</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>Properties</h3>
 <div class="list-group">
     {{#property-text name="timezone" type="String" required=true}}

--- a/tests/dummy/app/templates/demos/sl-date-time.hbs
+++ b/tests/dummy/app/templates/demos/sl-date-time.hbs
@@ -69,12 +69,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-date-time</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-date-time.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-date-time.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-drop-button.hbs
+++ b/tests/dummy/app/templates/demos/sl-drop-button.hbs
@@ -45,12 +45,12 @@
 
 <hr>
 
-<h3>sl-drop-button CSS Namespacing</h3>
+<h3>sl-drop-button Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-drop-button</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-drop-button.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-drop-button.</p>
     </div>
 </div>
 
@@ -90,12 +90,12 @@
 
 <hr>
 
-<h3>sl-drop-option CSS Namespacing</h3>
+<h3>sl-drop-option Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-drop-option</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-drop-option.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-drop-option.</p>
     </div>
 </div>
 
@@ -115,12 +115,12 @@
 
 <hr>
 
-<h3>sl-drop-option-divider CSS Namespacing</h3>
+<h3>sl-drop-option-divider Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-drop-option-divider</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-drop-option-divider.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-drop-option-divider.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-drop-button.hbs
+++ b/tests/dummy/app/templates/demos/sl-drop-button.hbs
@@ -45,6 +45,17 @@
 
 <hr>
 
+<h3>sl-drop-button CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-drop-button</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-drop-button.</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>sl-drop-button Properties</h3>
 
 <div class="list-group">
@@ -79,6 +90,17 @@
 
 <hr>
 
+<h3>sl-drop-option CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-drop-option</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-drop-option.</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>sl-drop-option Properties</h3>
 
 <div class="list-group">
@@ -89,6 +111,17 @@
     {{#property-text name="label" type="String"}}
         Text label for the option in the menu. If this property is omitted, the option becomes a divider.
     {{/property-text}}
+</div>
+
+<hr>
+
+<h3>sl-drop-option-divider CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-drop-option-divider</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-drop-option-divider.</p>
+    </div>
 </div>
 
 <h3>sl-drop-option-divider</h3>

--- a/tests/dummy/app/templates/demos/sl-grid.hbs
+++ b/tests/dummy/app/templates/demos/sl-grid.hbs
@@ -91,12 +91,12 @@ rowActions: [
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-grid</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-grid.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-grid.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-grid.hbs
+++ b/tests/dummy/app/templates/demos/sl-grid.hbs
@@ -91,6 +91,17 @@ rowActions: [
 
 <hr>
 
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-grid</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-grid.</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>Properties</h3>
 
 <div class="list-group">

--- a/tests/dummy/app/templates/demos/sl-input.hbs
+++ b/tests/dummy/app/templates/demos/sl-input.hbs
@@ -210,12 +210,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-input</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-input.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-input.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-input.hbs
+++ b/tests/dummy/app/templates/demos/sl-input.hbs
@@ -199,8 +199,23 @@
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-component-input-id</p>
+    </div>
+    <div class="list-group-item">
         <p>sl-input-based</p>
+    </div>
+    <div class="list-group-item">
         <p>sl-tooltip-enabled</p>
+    </div>
+</div>
+
+<hr>
+
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-input</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-input.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-menu.hbs
+++ b/tests/dummy/app/templates/demos/sl-menu.hbs
@@ -44,6 +44,17 @@
 
 <hr>
 
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-menu</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-menu.</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>Properties</h3>
 
 <ul class="list-group">

--- a/tests/dummy/app/templates/demos/sl-menu.hbs
+++ b/tests/dummy/app/templates/demos/sl-menu.hbs
@@ -44,12 +44,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-menu</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-menu.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-menu.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-modal.hbs
+++ b/tests/dummy/app/templates/demos/sl-modal.hbs
@@ -137,12 +137,12 @@
 
 <hr>
 
-<h3>sl-modal CSS Namespacing</h3>
+<h3>sl-modal Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-modal</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-modal.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-modal.</p>
     </div>
 </div>
 
@@ -183,12 +183,12 @@
 
 <hr>
 
-<h3> sl-modal-header CSS Namespacing</h3>
+<h3> sl-modal-header Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-modal-header</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-modal-header.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-modal-header.</p>
     </div>
 </div>
 
@@ -202,23 +202,23 @@
 
 <hr>
 
-<h3>sl-modal-body CSS Namespacing</h3>
+<h3>sl-modal-body Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-modal-body</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-modal-body.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-modal-body.</p>
     </div>
 </div>
 
 <hr>
 
-<h3>sl-modal-footer CSS Namespacing</h3>
+<h3>sl-modal-footer Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-modal-footer</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-modal-footer.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-modal-footer.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-modal.hbs
+++ b/tests/dummy/app/templates/demos/sl-modal.hbs
@@ -137,6 +137,17 @@
 
 <hr>
 
+<h3>sl-modal CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-modal</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-modal.</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>sl-modal Properties</h3>
 {{#property-text name="afterHide" type="Function"}}
     Action to call after modal is shown.
@@ -172,11 +183,44 @@
 
 <hr>
 
+<h3> sl-modal-header CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-modal-header</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-modal-header.</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>sl-modal-header Properties</h3>
 
 {{#property-text name="title" type="String"}}
     Title of the modal.
 {{/property-text}}
+
+<hr>
+
+<h3>sl-modal-body CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-modal-body</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-modal-body.</p>
+    </div>
+</div>
+
+<hr>
+
+<h3>sl-modal-footer CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-modal-footer</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-modal-footer.</p>
+    </div>
+</div>
 
 <hr>
 

--- a/tests/dummy/app/templates/demos/sl-pagination.hbs
+++ b/tests/dummy/app/templates/demos/sl-pagination.hbs
@@ -18,12 +18,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-pagination</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-pagination.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-pagination.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-pagination.hbs
+++ b/tests/dummy/app/templates/demos/sl-pagination.hbs
@@ -18,6 +18,17 @@
 
 <hr>
 
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-pagination</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-pagination.</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>Properties</h3>
 
 <div class="list-group">

--- a/tests/dummy/app/templates/demos/sl-panel.hbs
+++ b/tests/dummy/app/templates/demos/sl-panel.hbs
@@ -55,12 +55,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-panel</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-panel.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-panel.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-panel.hbs
+++ b/tests/dummy/app/templates/demos/sl-panel.hbs
@@ -55,6 +55,17 @@
 
 <hr>
 
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-panel</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-panel.</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>Properties</h3>
 
 <div class="list-group">

--- a/tests/dummy/app/templates/demos/sl-progress-bar.hbs
+++ b/tests/dummy/app/templates/demos/sl-progress-bar.hbs
@@ -90,12 +90,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-progress-bar</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-progress-bar.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-progress-bar.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-progress-bar.hbs
+++ b/tests/dummy/app/templates/demos/sl-progress-bar.hbs
@@ -90,6 +90,17 @@
 
 <hr>
 
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-progress-bar</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-progress-bar.</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>Properties</h3>
 
 <div class="group-list">

--- a/tests/dummy/app/templates/demos/sl-radio-group.hbs
+++ b/tests/dummy/app/templates/demos/sl-radio-group.hbs
@@ -46,7 +46,20 @@
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-input-based</p>
+    </div>
+    <div class="list-group-item">
         <p>sl-tooltip-enabled</p>
+    </div>
+</div>
+
+<hr>
+
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-radio-group</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-radio-group.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-radio-group.hbs
+++ b/tests/dummy/app/templates/demos/sl-radio-group.hbs
@@ -54,12 +54,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-radio-group</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-radio-group.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-radio-group.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-radio.hbs
+++ b/tests/dummy/app/templates/demos/sl-radio.hbs
@@ -41,6 +41,17 @@
 
 <hr>
 
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-radio</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-radio.</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>Properties</h3>
 
 <div class="list-group">

--- a/tests/dummy/app/templates/demos/sl-radio.hbs
+++ b/tests/dummy/app/templates/demos/sl-radio.hbs
@@ -41,12 +41,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-radio</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-radio.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-radio.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-select.hbs
+++ b/tests/dummy/app/templates/demos/sl-select.hbs
@@ -56,7 +56,20 @@
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-input-based</p>
+    </div>
+    <div class="list-group-item">
         <p>sl-tooltip-enabled</p>
+    </div>
+</div>
+
+<hr>
+
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-select</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-select.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-select.hbs
+++ b/tests/dummy/app/templates/demos/sl-select.hbs
@@ -64,12 +64,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-select</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-select.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-select.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-span.hbs
+++ b/tests/dummy/app/templates/demos/sl-span.hbs
@@ -27,12 +27,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-span</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-span.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-span.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-span.hbs
+++ b/tests/dummy/app/templates/demos/sl-span.hbs
@@ -27,6 +27,17 @@
 
 <hr>
 
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-span</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-span.</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>Properties</h3>
 
 <div class="list-group">

--- a/tests/dummy/app/templates/demos/sl-tab-panel.hbs
+++ b/tests/dummy/app/templates/demos/sl-tab-panel.hbs
@@ -43,6 +43,17 @@
 
 <hr>
 
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-tab-panel</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-tab-panel.</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>sl-tab-panel Properties</h3>
 
 <div class="list-group">

--- a/tests/dummy/app/templates/demos/sl-tab-panel.hbs
+++ b/tests/dummy/app/templates/demos/sl-tab-panel.hbs
@@ -43,12 +43,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-tab-panel</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-tab-panel.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-tab-panel.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-textarea.hbs
+++ b/tests/dummy/app/templates/demos/sl-textarea.hbs
@@ -65,12 +65,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-textarea</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-textarea.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-textarea.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-textarea.hbs
+++ b/tests/dummy/app/templates/demos/sl-textarea.hbs
@@ -54,8 +54,23 @@
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-component-input-id</p>
+    </div>
+    <div class="list-group-item">
         <p>sl-input-based</p>
+    </div>
+    <div class="list-group-item">
         <p>sl-tooltip-enabled</p>
+    </div>
+</div>
+
+<hr>
+
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-textarea</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-textarea.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-tooltip.hbs
+++ b/tests/dummy/app/templates/demos/sl-tooltip.hbs
@@ -57,12 +57,12 @@
 
 <hr>
 
-<h3>CSS Namespacing</h3>
+<h3>Custom CSS styling</h3>
 
 <div class="list-group">
     <div class="list-group-item">
         <p>sl-ember-components-tooltip</p>
-        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-tooltip.</p>
+        <p>The default class prefix is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the CSS class would be [customprefix]-tooltip.</p>
     </div>
 </div>
 

--- a/tests/dummy/app/templates/demos/sl-tooltip.hbs
+++ b/tests/dummy/app/templates/demos/sl-tooltip.hbs
@@ -57,6 +57,17 @@
 
 <hr>
 
+<h3>CSS Namespacing</h3>
+
+<div class="list-group">
+    <div class="list-group-item">
+        <p>sl-ember-components-tooltip</p>
+        <p>The default namespace is "sl-ember-components" unless the consuming application passes in a custom prefix. In which case, the namespace would be customprefix-tooltip.</p>
+    </div>
+</div>
+
+<hr>
+
 <h3>Properties</h3>
 
 <div class="list-group">


### PR DESCRIPTION
Closes softlayer/sl-ember-components#1387

Added CSS namespacing information to the demo app documentation for each component

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/softlayer/sl-ember-components/1484)
<!-- Reviewable:end -->
