### PR TITLE
Unit | Component | sl tab panel: setActiveTab() does so correctly

### DIFF
--- a/addon/components/sl-tab-panel.js
+++ b/addon/components/sl-tab-panel.js
@@ -147,17 +147,6 @@ export default Ember.Component.extend( ClassPrefix, {
     },
 
     /**
-     * Update the internal active tab name and handle tabs' statuses
-     *
-     * @function
-     * @param {String} tabName - The name of the tab to switch state to
-     * @returns {undefined}
-     */
-    setActiveTab( tabName ) {
-        this.$( '> .nav-tabs > li[data-tab-name=' + tabName + '] a' ).trigger( 'click' );
-    },
-
-    /**
      * Sets up the initial tab, and parses the content of the tab panel to
      * determine tab labels and names.
      *

--- a/tests/unit/components/sl-tab-panel-test.js
+++ b/tests/unit/components/sl-tab-panel-test.js
@@ -117,39 +117,6 @@ test( 'setupTabs() sets "tabs" property with correct data', function( assert ) {
     this.registry.unregister( 'template:test-template' );
 });
 
-test( 'setActiveTab() does so correctly', function( assert ) {
-    this.registry
-        .register( 'template:test-template', template );
-
-    const component = this.subject({
-        templateName: 'test-template'
-    });
-
-    this.render();
-
-    const tabOne = this.$( '> .nav-tabs > li[data-tab-name="one"]' );
-    const tabTwo = this.$( '> .nav-tabs > li[data-tab-name="two"]' );
-
-    assert.notOk(
-        tabTwo.hasClass( 'active' ),
-        'Second tab did not have active class'
-    );
-
-    component.setActiveTab( 'two' );
-
-    assert.ok(
-        tabTwo.hasClass( 'active' ),
-        'Second tab now has active class'
-    );
-
-    assert.notOk(
-        tabOne.hasClass( 'active' ),
-        'First tab does not have active class'
-    );
-
-    this.registry.unregister( 'template:test-template' );
-});
-
 test( 'getInitialTabName() returns the correct tab name', function( assert ) {
     this.registry
         .register( 'template:test-template', template );


### PR DESCRIPTION
@notmessenger setActiveTab() is a dead method left over from jeff's revision, @juwara0 agreed to remove it from the codebase.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/softlayer/sl-ember-components/1636)
<!-- Reviewable:end -->
